### PR TITLE
fix: Add lifetime parameter to objects dependent on `TermManager`

### DIFF
--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -1,6 +1,7 @@
 use cvc5_sys::*;
 use std::ffi::CString;
 use std::fmt;
+use std::marker::PhantomData;
 
 use crate::{Sort, Term};
 
@@ -9,27 +10,32 @@ use crate::{Sort, Term};
 // ---------------------------------------------------------------------------
 
 /// A declaration for a datatype constructor (before the datatype is resolved).
-pub struct DatatypeConstructorDecl {
+pub struct DatatypeConstructorDecl<'tm> {
     pub(crate) inner: cvc5_sys::DatatypeConstructorDecl,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for DatatypeConstructorDecl {
+impl Clone for DatatypeConstructorDecl<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { dt_cons_decl_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for DatatypeConstructorDecl {
+impl Drop for DatatypeConstructorDecl<'_> {
     fn drop(&mut self) {
         unsafe { dt_cons_decl_release(self.inner) }
     }
 }
 
-impl DatatypeConstructorDecl {
+impl<'tm> DatatypeConstructorDecl<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::DatatypeConstructorDecl) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Add a selector with the given name and codomain sort.
@@ -52,7 +58,7 @@ impl DatatypeConstructorDecl {
     }
 }
 
-impl fmt::Display for DatatypeConstructorDecl {
+impl fmt::Display for DatatypeConstructorDecl<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { dt_cons_decl_to_string(self.inner) };
         write!(f, "{}", unsafe {
@@ -61,20 +67,20 @@ impl fmt::Display for DatatypeConstructorDecl {
     }
 }
 
-impl PartialEq for DatatypeConstructorDecl {
+impl PartialEq for DatatypeConstructorDecl<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { dt_cons_decl_is_equal(self.inner, other.inner) }
     }
 }
-impl Eq for DatatypeConstructorDecl {}
+impl Eq for DatatypeConstructorDecl<'_> {}
 
-impl std::hash::Hash for DatatypeConstructorDecl {
+impl std::hash::Hash for DatatypeConstructorDecl<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { dt_cons_decl_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for DatatypeConstructorDecl {
+impl fmt::Debug for DatatypeConstructorDecl<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DatatypeConstructorDecl({self})")
     }
@@ -85,31 +91,36 @@ impl fmt::Debug for DatatypeConstructorDecl {
 // ---------------------------------------------------------------------------
 
 /// A declaration for a datatype (before it is resolved into a sort).
-pub struct DatatypeDecl {
+pub struct DatatypeDecl<'tm> {
     pub(crate) inner: cvc5_sys::DatatypeDecl,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for DatatypeDecl {
+impl Clone for DatatypeDecl<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { dt_decl_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for DatatypeDecl {
+impl Drop for DatatypeDecl<'_> {
     fn drop(&mut self) {
         unsafe { dt_decl_release(self.inner) }
     }
 }
 
-impl DatatypeDecl {
+impl<'tm> DatatypeDecl<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::DatatypeDecl) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Create a copy of this declaration (increments the internal reference count).
-    pub fn copy(&self) -> DatatypeDecl {
+    pub fn copy(&self) -> DatatypeDecl<'tm> {
         DatatypeDecl::from_raw(unsafe { dt_decl_copy(self.inner) })
     }
 
@@ -143,7 +154,7 @@ impl DatatypeDecl {
     }
 }
 
-impl fmt::Display for DatatypeDecl {
+impl fmt::Display for DatatypeDecl<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { dt_decl_to_string(self.inner) };
         write!(f, "{}", unsafe {
@@ -152,20 +163,20 @@ impl fmt::Display for DatatypeDecl {
     }
 }
 
-impl PartialEq for DatatypeDecl {
+impl PartialEq for DatatypeDecl<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { dt_decl_is_equal(self.inner, other.inner) }
     }
 }
-impl Eq for DatatypeDecl {}
+impl Eq for DatatypeDecl<'_> {}
 
-impl std::hash::Hash for DatatypeDecl {
+impl std::hash::Hash for DatatypeDecl<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { dt_decl_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for DatatypeDecl {
+impl fmt::Debug for DatatypeDecl<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DatatypeDecl({self})")
     }
@@ -176,31 +187,36 @@ impl fmt::Debug for DatatypeDecl {
 // ---------------------------------------------------------------------------
 
 /// A selector of a resolved datatype constructor.
-pub struct DatatypeSelector {
+pub struct DatatypeSelector<'tm> {
     pub(crate) inner: cvc5_sys::DatatypeSelector,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for DatatypeSelector {
+impl Clone for DatatypeSelector<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { dt_sel_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for DatatypeSelector {
+impl Drop for DatatypeSelector<'_> {
     fn drop(&mut self) {
         unsafe { dt_sel_release(self.inner) }
     }
 }
 
-impl DatatypeSelector {
+impl<'tm> DatatypeSelector<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::DatatypeSelector) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Create a copy of this selector (increments the internal reference count).
-    pub fn copy(&self) -> DatatypeSelector {
+    pub fn copy(&self) -> DatatypeSelector<'tm> {
         DatatypeSelector::from_raw(unsafe { dt_sel_copy(self.inner) })
     }
 
@@ -214,22 +230,22 @@ impl DatatypeSelector {
     }
 
     /// Get the selector function as a term.
-    pub fn term(&self) -> Term {
+    pub fn term(&self) -> Term<'tm> {
         Term::from_raw(unsafe { dt_sel_get_term(self.inner) })
     }
 
     /// Get the updater function as a term.
-    pub fn updater_term(&self) -> Term {
+    pub fn updater_term(&self) -> Term<'tm> {
         Term::from_raw(unsafe { dt_sel_get_updater_term(self.inner) })
     }
 
     /// Get the codomain (return) sort of this selector.
-    pub fn codomain_sort(&self) -> Sort {
+    pub fn codomain_sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { dt_sel_get_codomain_sort(self.inner) })
     }
 }
 
-impl fmt::Display for DatatypeSelector {
+impl fmt::Display for DatatypeSelector<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { dt_sel_to_string(self.inner) };
         write!(f, "{}", unsafe {
@@ -238,20 +254,20 @@ impl fmt::Display for DatatypeSelector {
     }
 }
 
-impl PartialEq for DatatypeSelector {
+impl PartialEq for DatatypeSelector<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { dt_sel_is_equal(self.inner, other.inner) }
     }
 }
-impl Eq for DatatypeSelector {}
+impl Eq for DatatypeSelector<'_> {}
 
-impl std::hash::Hash for DatatypeSelector {
+impl std::hash::Hash for DatatypeSelector<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { dt_sel_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for DatatypeSelector {
+impl fmt::Debug for DatatypeSelector<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DatatypeSelector({self})")
     }
@@ -262,27 +278,32 @@ impl fmt::Debug for DatatypeSelector {
 // ---------------------------------------------------------------------------
 
 /// A constructor of a resolved datatype.
-pub struct DatatypeConstructor {
+pub struct DatatypeConstructor<'tm> {
     pub(crate) inner: cvc5_sys::DatatypeConstructor,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for DatatypeConstructor {
+impl Clone for DatatypeConstructor<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { dt_cons_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for DatatypeConstructor {
+impl Drop for DatatypeConstructor<'_> {
     fn drop(&mut self) {
         unsafe { dt_cons_release(self.inner) }
     }
 }
 
-impl DatatypeConstructor {
+impl<'tm> DatatypeConstructor<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::DatatypeConstructor) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Get the name of this constructor.
@@ -295,17 +316,17 @@ impl DatatypeConstructor {
     }
 
     /// Get the constructor function as a term.
-    pub fn term(&self) -> Term {
+    pub fn term(&self) -> Term<'tm> {
         Term::from_raw(unsafe { dt_cons_get_term(self.inner) })
     }
 
     /// Get the constructor term instantiated for the given parametric datatype sort.
-    pub fn instantiated_term(&self, sort: Sort) -> Term {
+    pub fn instantiated_term(&self, sort: Sort) -> Term<'tm> {
         Term::from_raw(unsafe { dt_cons_get_instantiated_term(self.inner, sort.inner) })
     }
 
     /// Get the tester (discriminator) function as a term.
-    pub fn tester_term(&self) -> Term {
+    pub fn tester_term(&self) -> Term<'tm> {
         Term::from_raw(unsafe { dt_cons_get_tester_term(self.inner) })
     }
 
@@ -315,18 +336,18 @@ impl DatatypeConstructor {
     }
 
     /// Get the selector at the given index.
-    pub fn selector(&self, index: usize) -> DatatypeSelector {
+    pub fn selector(&self, index: usize) -> DatatypeSelector<'tm> {
         DatatypeSelector::from_raw(unsafe { dt_cons_get_selector(self.inner, index) })
     }
 
     /// Get a selector by name.
-    pub fn selector_by_name(&self, name: &str) -> DatatypeSelector {
+    pub fn selector_by_name(&self, name: &str) -> DatatypeSelector<'tm> {
         let c = CString::new(name).unwrap();
         DatatypeSelector::from_raw(unsafe { dt_cons_get_selector_by_name(self.inner, c.as_ptr()) })
     }
 }
 
-impl fmt::Display for DatatypeConstructor {
+impl fmt::Display for DatatypeConstructor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { dt_cons_to_string(self.inner) };
         write!(f, "{}", unsafe {
@@ -335,20 +356,20 @@ impl fmt::Display for DatatypeConstructor {
     }
 }
 
-impl PartialEq for DatatypeConstructor {
+impl PartialEq for DatatypeConstructor<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { dt_cons_is_equal(self.inner, other.inner) }
     }
 }
-impl Eq for DatatypeConstructor {}
+impl Eq for DatatypeConstructor<'_> {}
 
-impl std::hash::Hash for DatatypeConstructor {
+impl std::hash::Hash for DatatypeConstructor<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { dt_cons_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for DatatypeConstructor {
+impl fmt::Debug for DatatypeConstructor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DatatypeConstructor({self})")
     }
@@ -362,47 +383,52 @@ impl fmt::Debug for DatatypeConstructor {
 ///
 /// Obtained from a sort via [`Sort::datatype`] after the datatype has been
 /// created with [`TermManager::mk_dt_sort`](crate::TermManager::mk_dt_sort).
-pub struct Datatype {
+pub struct Datatype<'tm> {
     pub(crate) inner: cvc5_sys::Datatype,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for Datatype {
+impl Clone for Datatype<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { dt_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for Datatype {
+impl Drop for Datatype<'_> {
     fn drop(&mut self) {
         unsafe { dt_release(self.inner) }
     }
 }
 
-impl Datatype {
+impl<'tm> Datatype<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::Datatype) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Create a copy of this datatype (increments the internal reference count).
-    pub fn copy(&self) -> Datatype {
+    pub fn copy(&self) -> Datatype<'tm> {
         Datatype::from_raw(unsafe { dt_copy(self.inner) })
     }
 
     /// Get the constructor at the given index.
-    pub fn constructor(&self, index: usize) -> DatatypeConstructor {
+    pub fn constructor(&self, index: usize) -> DatatypeConstructor<'tm> {
         DatatypeConstructor::from_raw(unsafe { dt_get_constructor(self.inner, index) })
     }
 
     /// Get a constructor by name.
-    pub fn constructor_by_name(&self, name: &str) -> DatatypeConstructor {
+    pub fn constructor_by_name(&self, name: &str) -> DatatypeConstructor<'tm> {
         let c = CString::new(name).unwrap();
         DatatypeConstructor::from_raw(unsafe { dt_get_constructor_by_name(self.inner, c.as_ptr()) })
     }
 
     /// Get a selector by name (searches all constructors).
-    pub fn selector(&self, name: &str) -> DatatypeSelector {
+    pub fn selector(&self, name: &str) -> DatatypeSelector<'tm> {
         let c = CString::new(name).unwrap();
         DatatypeSelector::from_raw(unsafe { dt_get_selector(self.inner, c.as_ptr()) })
     }
@@ -422,7 +448,7 @@ impl Datatype {
     }
 
     /// Get the sort parameters of a parametric datatype.
-    pub fn parameters(&self) -> Vec<Sort> {
+    pub fn parameters(&self) -> Vec<Sort<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { dt_get_parameters(self.inner, &mut size) };
         (0..size)
@@ -461,7 +487,7 @@ impl Datatype {
     }
 }
 
-impl fmt::Display for Datatype {
+impl fmt::Display for Datatype<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { dt_to_string(self.inner) };
         write!(f, "{}", unsafe {
@@ -470,20 +496,20 @@ impl fmt::Display for Datatype {
     }
 }
 
-impl PartialEq for Datatype {
+impl PartialEq for Datatype<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { dt_is_equal(self.inner, other.inner) }
     }
 }
-impl Eq for Datatype {}
+impl Eq for Datatype<'_> {}
 
-impl std::hash::Hash for Datatype {
+impl std::hash::Hash for Datatype<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { dt_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for Datatype {
+impl fmt::Debug for Datatype<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Datatype({self})")
     }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,36 +1,42 @@
 use cvc5_sys::*;
 use std::fmt;
+use std::marker::PhantomData;
 
 use crate::Term;
 
 /// A cvc5 grammar for syntax-guided synthesis (SyGuS).
 ///
 /// Grammars constrain the space of candidate solutions in synthesis queries.
-pub struct Grammar {
+pub struct Grammar<'tm> {
     pub(crate) inner: cvc5_sys::Grammar,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for Grammar {
+impl Clone for Grammar<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { grammar_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for Grammar {
+impl Drop for Grammar<'_> {
     fn drop(&mut self) {
         unsafe { grammar_release(self.inner) }
     }
 }
 
-impl Grammar {
+impl<'tm> Grammar<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::Grammar) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Create a copy of this grammar (increments the internal reference count).
-    pub fn copy(&self) -> Grammar {
+    pub fn copy(&self) -> Grammar<'tm> {
         Grammar::from_raw(unsafe { grammar_copy(self.inner) })
     }
 
@@ -61,7 +67,7 @@ impl Grammar {
     }
 }
 
-impl fmt::Display for Grammar {
+impl fmt::Display for Grammar<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { grammar_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
@@ -69,21 +75,21 @@ impl fmt::Display for Grammar {
     }
 }
 
-impl PartialEq for Grammar {
+impl PartialEq for Grammar<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { grammar_is_equal(self.inner, other.inner) }
     }
 }
 
-impl Eq for Grammar {}
+impl Eq for Grammar<'_> {}
 
-impl std::hash::Hash for Grammar {
+impl std::hash::Hash for Grammar<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { grammar_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for Grammar {
+impl fmt::Debug for Grammar<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Grammar({self})")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ pub use cvc5_sys::InputLanguage;
 #[cfg(feature = "parser")]
 pub use parser::{Command, InputParser, SymbolManager};
 
+// Re-export PhantomData-related marker so users don't need to import it
+// (the lifetime is inferred automatically in most cases)
+
 /// Get a string representation of an [`InputLanguage`].
 #[cfg(feature = "parser")]
 pub fn input_language_to_string(lang: InputLanguage) -> String {

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,5 +1,6 @@
 use cvc5_sys::*;
 use std::fmt;
+use std::marker::PhantomData;
 
 use crate::Term;
 
@@ -7,27 +8,32 @@ use crate::Term;
 ///
 /// Operators are used to create terms with parameterized kinds, such as
 /// bit-vector extract with specific indices.
-pub struct Op {
+pub struct Op<'tm> {
     pub(crate) inner: cvc5_sys::Op,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for Op {
+impl Clone for Op<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { op_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for Op {
+impl Drop for Op<'_> {
     fn drop(&mut self) {
         unsafe { op_release(self.inner) }
     }
 }
 
-impl Op {
+impl<'tm> Op<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::Op) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Get the kind of this operator.
@@ -36,7 +42,7 @@ impl Op {
     }
 
     /// Create a copy of this operator (increments the internal reference count).
-    pub fn copy(&self) -> Op {
+    pub fn copy(&self) -> Op<'tm> {
         Op::from_raw(unsafe { op_copy(self.inner) })
     }
 
@@ -56,12 +62,12 @@ impl Op {
     }
 
     /// Get the index at position `i` as a term.
-    pub fn index(&self, i: usize) -> Term {
+    pub fn index(&self, i: usize) -> Term<'tm> {
         Term::from_raw(unsafe { op_get_index(self.inner, i) })
     }
 }
 
-impl fmt::Display for Op {
+impl fmt::Display for Op<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { op_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
@@ -69,21 +75,21 @@ impl fmt::Display for Op {
     }
 }
 
-impl fmt::Debug for Op {
+impl fmt::Debug for Op<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Op({self})")
     }
 }
 
-impl PartialEq for Op {
+impl PartialEq for Op<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { op_is_equal(self.inner, other.inner) }
     }
 }
 
-impl Eq for Op {}
+impl Eq for Op<'_> {}
 
-impl std::hash::Hash for Op {
+impl std::hash::Hash for Op<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { op_hash(self.inner) }.hash(state);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,7 +95,7 @@ impl SymbolManager {
     /// Get the sorts declared via `declare-sort` commands.
     ///
     /// These are the sorts printed as part of a `get-model` response.
-    pub fn get_declared_sorts(&self) -> Vec<Sort> {
+    pub fn get_declared_sorts(&self) -> Vec<Sort<'_>> {
         let mut size = 0usize;
         let ptr = unsafe { sm_get_declared_sorts(self.ptr(), &mut size) };
         (0..size)
@@ -106,7 +106,7 @@ impl SymbolManager {
     /// Get the terms declared via `declare-fun` and `declare-const` commands.
     ///
     /// These are the terms printed in a `get-model` response.
-    pub fn get_declared_terms(&self) -> Vec<Term> {
+    pub fn get_declared_terms(&self) -> Vec<Term<'_>> {
         let mut size = 0usize;
         let ptr = unsafe { sm_get_declared_terms(self.ptr(), &mut size) };
         (0..size)
@@ -117,7 +117,7 @@ impl SymbolManager {
     /// Get terms that have been given names via the `:named` attribute.
     ///
     /// Returns a list of `(term, name)` pairs.
-    pub fn get_named_terms(&self) -> Vec<(Term, String)> {
+    pub fn get_named_terms(&self) -> Vec<(Term<'_>, String)> {
         let mut size = 0usize;
         let mut terms: *mut cvc5_sys::Term = std::ptr::null_mut();
         let mut names: *mut *const std::os::raw::c_char = std::ptr::null_mut();
@@ -168,7 +168,7 @@ impl Command {
     ///
     /// Returns any output produced by the command (e.g. `sat`, `unsat`,
     /// model output, etc.).
-    pub fn invoke(&self, solver: &mut Solver, sm: &mut SymbolManager) -> String {
+    pub fn invoke(&self, solver: &mut Solver<'_>, sm: &mut SymbolManager) -> String {
         unsafe {
             std::ffi::CStr::from_ptr(cmd_invoke(self.inner, solver.inner, sm.ptr()))
                 .to_string_lossy()
@@ -214,14 +214,14 @@ impl fmt::Debug for Command {
 /// Then call [`next_command`](InputParser::next_command) or
 /// [`next_term`](InputParser::next_term) in a loop until
 /// [`done`](InputParser::done) returns `true`.
-pub struct InputParser {
+pub struct InputParser<'tm> {
     inner: *mut cvc5_sys::parser::InputParser,
     /// This field is public for reclaiming the ownership of the solver
-    pub solver: Solver,
+    pub solver: Solver<'tm>,
     sm: SymbolManager,
 }
 
-impl InputParser {
+impl<'tm> InputParser<'tm> {
     /// Create a new input parser.
     ///
     /// - `solver` — the solver that parsed commands will target.
@@ -230,7 +230,7 @@ impl InputParser {
     ///
     /// If both the solver and symbol manager have their logic set, the logics
     /// must be the same.
-    pub fn new(solver: Solver, sm: Option<impl std::borrow::Borrow<SymbolManager>>) -> Self {
+    pub fn new(solver: Solver<'tm>, sm: Option<impl std::borrow::Borrow<SymbolManager>>) -> Self {
         let sm = sm
             .map(|sm| sm.borrow().clone())
             .unwrap_or_else(|| SymbolManager::new(&solver.tm));
@@ -243,7 +243,7 @@ impl InputParser {
     }
 
     /// Return a mutable reference to the solver associated with this parser.
-    pub fn get_solver(&mut self) -> &mut Solver {
+    pub fn get_solver(&mut self) -> &mut Solver<'tm> {
         &mut self.solver
     }
 
@@ -305,7 +305,7 @@ impl InputParser {
     ///
     /// If no logic has been set, the first command that requires one will
     /// initialize the logic to `"ALL"`.
-    pub fn next_command(&mut self) -> Result<Option<Command>, String> {
+    pub fn next_command(&mut self) -> std::result::Result<Option<Command>, String> {
         let mut error_msg: *const std::os::raw::c_char = std::ptr::null();
         let cmd = unsafe { parser_next_command(self.inner, &mut error_msg) };
         if !error_msg.is_null() {
@@ -329,7 +329,7 @@ impl InputParser {
     /// - `Err(msg)` — a parse error with the error message.
     ///
     /// The logic must be set before calling this method.
-    pub fn next_term(&mut self) -> Result<Option<Term>, String> {
+    pub fn next_term(&mut self) -> std::result::Result<Option<Term<'_>>, String> {
         let mut error_msg: *const std::os::raw::c_char = std::ptr::null();
         let term = unsafe { parser_next_term(self.inner, &mut error_msg) };
         if !error_msg.is_null() {
@@ -351,7 +351,7 @@ impl InputParser {
     }
 }
 
-impl Drop for InputParser {
+impl Drop for InputParser<'_> {
     fn drop(&mut self) {
         unsafe { parser_delete(self.inner) }
     }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,5 +1,6 @@
 use cvc5_sys::*;
 use std::fmt;
+use std::marker::PhantomData;
 
 use crate::Term;
 
@@ -7,27 +8,32 @@ use crate::Term;
 ///
 /// Proofs are produced when the solver is configured with
 /// `set_option("produce-proofs", "true")` and a query returns unsat.
-pub struct Proof {
+pub struct Proof<'tm> {
     pub(crate) inner: cvc5_sys::Proof,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for Proof {
+impl Clone for Proof<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { proof_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for Proof {
+impl Drop for Proof<'_> {
     fn drop(&mut self) {
         unsafe { proof_release(self.inner) }
     }
 }
 
-impl Proof {
+impl<'tm> Proof<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::Proof) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Get the proof rule used at the root of this proof node.
@@ -36,7 +42,7 @@ impl Proof {
     }
 
     /// Create a copy of this proof (increments the internal reference count).
-    pub fn copy(&self) -> Proof {
+    pub fn copy(&self) -> Proof<'tm> {
         Proof::from_raw(unsafe { proof_copy(self.inner) })
     }
 
@@ -51,12 +57,12 @@ impl Proof {
     }
 
     /// Get the conclusion (result) of this proof node as a term.
-    pub fn result(&self) -> Term {
+    pub fn result(&self) -> Term<'tm> {
         Term::from_raw(unsafe { proof_get_result(self.inner) })
     }
 
     /// Get the child proof nodes.
-    pub fn children(&self) -> Vec<Proof> {
+    pub fn children(&self) -> Vec<Proof<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { proof_get_children(self.inner, &mut size) };
         (0..size)
@@ -65,7 +71,7 @@ impl Proof {
     }
 
     /// Get the arguments of this proof node as terms.
-    pub fn arguments(&self) -> Vec<Term> {
+    pub fn arguments(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { proof_get_arguments(self.inner, &mut size) };
         (0..size)
@@ -74,21 +80,21 @@ impl Proof {
     }
 }
 
-impl PartialEq for Proof {
+impl PartialEq for Proof<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { proof_is_equal(self.inner, other.inner) }
     }
 }
 
-impl Eq for Proof {}
+impl Eq for Proof<'_> {}
 
-impl std::hash::Hash for Proof {
+impl std::hash::Hash for Proof<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { proof_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for Proof {
+impl fmt::Debug for Proof<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Proof({:?})", self.rule())
     }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,28 +1,34 @@
 use cvc5_sys::*;
 use std::fmt;
+use std::marker::PhantomData;
 
 /// The result of a satisfiability check.
-pub struct Result {
+pub struct Result<'tm> {
     pub(crate) inner: cvc5_sys::Result,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for Result {
+impl Clone for Result<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { result_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for Result {
+impl Drop for Result<'_> {
     fn drop(&mut self) {
         unsafe { result_release(self.inner) }
     }
 }
 
-impl Result {
+impl<'tm> Result<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::Result) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Return `true` if this is a null (uninitialized) result.
@@ -31,7 +37,7 @@ impl Result {
     }
 
     /// Create a copy of this result (increments the internal reference count).
-    pub fn copy(&self) -> Result {
+    pub fn copy(&self) -> Result<'tm> {
         Result::from_raw(unsafe { result_copy(self.inner) })
     }
 
@@ -61,7 +67,7 @@ impl Result {
     }
 }
 
-impl fmt::Display for Result {
+impl fmt::Display for Result<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { result_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
@@ -69,21 +75,21 @@ impl fmt::Display for Result {
     }
 }
 
-impl fmt::Debug for Result {
+impl fmt::Debug for Result<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Result({self})")
     }
 }
 
-impl PartialEq for Result {
+impl PartialEq for Result<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { result_is_equal(self.inner, other.inner) }
     }
 }
 
-impl Eq for Result {}
+impl Eq for Result<'_> {}
 
-impl std::hash::Hash for Result {
+impl std::hash::Hash for Result<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { result_hash(self.inner) }.hash(state);
     }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,6 +1,6 @@
 use cvc5_sys::*;
-use std::borrow::Borrow;
 use std::ffi::CString;
+use std::marker::PhantomData;
 
 use crate::{
     DatatypeConstructorDecl, Grammar, Proof, Result, Sort, Statistics, SynthResult, Term,
@@ -9,20 +9,22 @@ use crate::{
 
 /// A cvc5 solver instance.
 ///
-/// Holds a clone of the [`TermManager`] that created it, ensuring the
-/// underlying C term manager outlives this solver.
-pub struct Solver {
+/// The lifetime `'tm` ties this solver to the [`TermManager`] that created it,
+/// ensuring the term manager outlives the solver and all objects it produces.
+pub struct Solver<'tm> {
     pub(crate) inner: *mut cvc5_sys::Solver,
     pub(crate) tm: TermManager,
+    _phantom: PhantomData<&'tm ()>,
 }
 
-impl Solver {
+impl<'tm> Solver<'tm> {
     /// Create a new solver instance from the given term manager.
-    pub fn new(tm: impl Borrow<TermManager>) -> Self {
-        let tm = tm.borrow().clone();
+    pub fn new(tm: &'tm TermManager) -> Self {
+        let tm_clone = tm.clone();
         Self {
-            inner: unsafe { new(tm.ptr()) },
-            tm,
+            inner: unsafe { new(tm_clone.ptr()) },
+            tm: tm_clone,
+            _phantom: PhantomData,
         }
     }
 
@@ -108,18 +110,18 @@ impl Solver {
     }
 
     /// Check satisfiability of the current assertions.
-    pub fn check_sat(&mut self) -> Result {
+    pub fn check_sat(&mut self) -> Result<'tm> {
         Result::from_raw(unsafe { check_sat(self.inner) })
     }
 
     /// Check satisfiability under the given assumptions.
-    pub fn check_sat_assuming(&mut self, assumptions: &[Term]) -> Result {
+    pub fn check_sat_assuming(&mut self, assumptions: &[Term]) -> Result<'tm> {
         let raw: Vec<cvc5_sys::Term> = assumptions.iter().map(|t| t.inner).collect();
         Result::from_raw(unsafe { check_sat_assuming(self.inner, raw.len(), raw.as_ptr()) })
     }
 
     /// Get the list of asserted formulas.
-    pub fn get_assertions(&self) -> Vec<Term> {
+    pub fn get_assertions(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_assertions(self.inner, &mut size) };
         (0..size)
@@ -130,19 +132,19 @@ impl Solver {
     // ── Simplification ─────────────────────────────────────────────
 
     /// Simplify a term. If `apply_subs` is true, apply learned substitutions.
-    pub fn simplify(&self, term: Term, apply_subs: bool) -> Term {
+    pub fn simplify(&self, term: Term, apply_subs: bool) -> Term<'tm> {
         Term::from_raw(unsafe { simplify(self.inner, term.inner, apply_subs) })
     }
 
     // ── Model queries ──────────────────────────────────────────────
 
     /// Get the value of a term in the current model.
-    pub fn get_value(&self, term: Term) -> Term {
+    pub fn get_value(&self, term: Term) -> Term<'tm> {
         Term::from_raw(unsafe { get_value(self.inner, term.inner) })
     }
 
     /// Get the values of multiple terms in the current model.
-    pub fn get_values(&self, terms: &[Term]) -> Vec<Term> {
+    pub fn get_values(&self, terms: &[Term]) -> Vec<Term<'tm>> {
         let raw: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
         let mut rsize = 0usize;
         let ptr = unsafe { get_values(self.inner, raw.len(), raw.as_ptr(), &mut rsize) };
@@ -152,7 +154,7 @@ impl Solver {
     }
 
     /// Get the domain elements of an uninterpreted sort in the current model.
-    pub fn get_model_domain_elements(&self, sort: Sort) -> Vec<Term> {
+    pub fn get_model_domain_elements(&self, sort: Sort) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_model_domain_elements(self.inner, sort.inner, &mut size) };
         (0..size)
@@ -196,7 +198,7 @@ impl Solver {
     // ── Declarations ───────────────────────────────────────────────
 
     /// Declare a function (SMT-LIB `declare-fun`).
-    pub fn declare_fun(&mut self, name: &str, domain: &[Sort], codomain: Sort) -> Term {
+    pub fn declare_fun(&mut self, name: &str, domain: &[Sort], codomain: Sort) -> Term<'tm> {
         let c = CString::new(name).unwrap();
         let raw: Vec<cvc5_sys::Sort> = domain.iter().map(|s| s.inner).collect();
         Term::from_raw(unsafe {
@@ -212,13 +214,13 @@ impl Solver {
     }
 
     /// Declare an uninterpreted sort (SMT-LIB `declare-sort`).
-    pub fn declare_sort(&mut self, name: &str, arity: u32) -> Sort {
+    pub fn declare_sort(&mut self, name: &str, arity: u32) -> Sort<'tm> {
         let c = CString::new(name).unwrap();
         Sort::from_raw(unsafe { declare_sort(self.inner, c.as_ptr(), arity, true) })
     }
 
     /// Declare a datatype from constructor declarations.
-    pub fn declare_dt(&mut self, symbol: &str, ctors: &[DatatypeConstructorDecl]) -> Sort {
+    pub fn declare_dt(&mut self, symbol: &str, ctors: &[DatatypeConstructorDecl]) -> Sort<'tm> {
         let c = CString::new(symbol).unwrap();
         let raw: Vec<cvc5_sys::DatatypeConstructorDecl> = ctors.iter().map(|d| d.inner).collect();
         Sort::from_raw(unsafe { declare_dt(self.inner, c.as_ptr(), raw.len(), raw.as_ptr()) })
@@ -234,7 +236,7 @@ impl Solver {
         sort: Sort,
         term: Term,
         global: bool,
-    ) -> Term {
+    ) -> Term<'tm> {
         let c = CString::new(symbol).unwrap();
         let raw: Vec<cvc5_sys::Term> = vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
@@ -258,7 +260,7 @@ impl Solver {
         sort: Sort,
         term: Term,
         global: bool,
-    ) -> Term {
+    ) -> Term<'tm> {
         let c = CString::new(symbol).unwrap();
         let raw: Vec<cvc5_sys::Term> = vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
@@ -281,7 +283,7 @@ impl Solver {
         vars: &[Term],
         term: Term,
         global: bool,
-    ) -> Term {
+    ) -> Term<'tm> {
         let raw: Vec<cvc5_sys::Term> = vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
             define_fun_rec_from_const(
@@ -313,7 +315,7 @@ impl Solver {
     // ── Unsat core / assumptions ───────────────────────────────────
 
     /// Get the unsat core (subset of assertions that are unsatisfiable).
-    pub fn get_unsat_core(&self) -> Vec<Term> {
+    pub fn get_unsat_core(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_unsat_core(self.inner, &mut size) };
         (0..size)
@@ -322,7 +324,7 @@ impl Solver {
     }
 
     /// Get the lemmas used in the unsat core.
-    pub fn get_unsat_core_lemmas(&self) -> Vec<Term> {
+    pub fn get_unsat_core_lemmas(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_unsat_core_lemmas(self.inner, &mut size) };
         (0..size)
@@ -331,7 +333,7 @@ impl Solver {
     }
 
     /// Get the unsat assumptions (subset of assumptions from `check_sat_assuming`).
-    pub fn get_unsat_assumptions(&self) -> Vec<Term> {
+    pub fn get_unsat_assumptions(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_unsat_assumptions(self.inner, &mut size) };
         (0..size)
@@ -342,7 +344,7 @@ impl Solver {
     // ── Proofs ─────────────────────────────────────────────────────
 
     /// Get the proof of unsatisfiability.
-    pub fn get_proof(&self, c: cvc5_sys::ProofComponent) -> Vec<Proof> {
+    pub fn get_proof(&self, c: cvc5_sys::ProofComponent) -> Vec<Proof<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_proof(self.inner, c, &mut size) };
         (0..size)
@@ -378,7 +380,7 @@ impl Solver {
     // ── Learned literals / difficulty ──────────────────────────────
 
     /// Get the learned literals of the given type.
-    pub fn get_learned_literals(&self, lit_type: cvc5_sys::LearnedLitType) -> Vec<Term> {
+    pub fn get_learned_literals(&self, lit_type: cvc5_sys::LearnedLitType) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_learned_literals(self.inner, lit_type, &mut size) };
         (0..size)
@@ -387,7 +389,7 @@ impl Solver {
     }
 
     /// Get the difficulty of each assertion as `(inputs, values)` pairs.
-    pub fn get_difficulty(&self) -> (Vec<Term>, Vec<Term>) {
+    pub fn get_difficulty(&self) -> (Vec<Term<'tm>>, Vec<Term<'tm>>) {
         let mut size = 0usize;
         let mut inputs: *mut cvc5_sys::Term = std::ptr::null_mut();
         let mut values: *mut cvc5_sys::Term = std::ptr::null_mut();
@@ -404,7 +406,7 @@ impl Solver {
     // ── Timeout core ───────────────────────────────────────────────
 
     /// Get a timeout core: a minimal subset of assertions causing a timeout.
-    pub fn get_timeout_core(&mut self) -> (Result, Vec<Term>) {
+    pub fn get_timeout_core(&mut self) -> (Result<'tm>, Vec<Term<'tm>>) {
         let mut result: cvc5_sys::Result = std::ptr::null_mut();
         let mut size = 0usize;
         let ptr = unsafe { get_timeout_core(self.inner, &mut result, &mut size) };
@@ -415,7 +417,7 @@ impl Solver {
     }
 
     /// Get a timeout core under the given assumptions.
-    pub fn get_timeout_core_assuming(&mut self, assumptions: &[Term]) -> (Result, Vec<Term>) {
+    pub fn get_timeout_core_assuming(&self, assumptions: &[Term]) -> (Result<'tm>, Vec<Term<'tm>>) {
         let raw: Vec<cvc5_sys::Term> = assumptions.iter().map(|t| t.inner).collect();
         let mut result: cvc5_sys::Result = std::ptr::null_mut();
         let mut rsize = 0usize;
@@ -431,12 +433,12 @@ impl Solver {
     // ── Quantifier elimination ─────────────────────────────────────
 
     /// Perform quantifier elimination on the given formula.
-    pub fn get_quantifier_elimination(&self, q: Term) -> Term {
+    pub fn get_quantifier_elimination(&self, q: Term) -> Term<'tm> {
         Term::from_raw(unsafe { get_quantifier_elimination(self.inner, q.inner) })
     }
 
     /// Perform partial quantifier elimination, returning a single disjunct.
-    pub fn get_quantifier_elimination_disjunct(&self, q: Term) -> Term {
+    pub fn get_quantifier_elimination_disjunct(&self, q: Term) -> Term<'tm> {
         Term::from_raw(unsafe { get_quantifier_elimination_disjunct(self.inner, q.inner) })
     }
 
@@ -448,19 +450,19 @@ impl Solver {
     }
 
     /// Get the separation logic heap term.
-    pub fn get_value_sep_heap(&self) -> Term {
+    pub fn get_value_sep_heap(&self) -> Term<'tm> {
         Term::from_raw(unsafe { get_value_sep_heap(self.inner) })
     }
 
     /// Get the separation logic nil term.
-    pub fn get_value_sep_nil(&self) -> Term {
+    pub fn get_value_sep_nil(&self) -> Term<'tm> {
         Term::from_raw(unsafe { get_value_sep_nil(self.inner) })
     }
 
     // ── Pools ──────────────────────────────────────────────────────
 
     /// Declare a term pool with the given initial values.
-    pub fn declare_pool(&mut self, symbol: &str, sort: Sort, init_value: &[Term]) -> Term {
+    pub fn declare_pool(&mut self, symbol: &str, sort: Sort, init_value: &[Term]) -> Term<'tm> {
         let c = CString::new(symbol).unwrap();
         let raw: Vec<cvc5_sys::Term> = init_value.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
@@ -473,7 +475,7 @@ impl Solver {
     /// Compute an interpolant for the given conjecture.
     ///
     /// Returns `None` if no interpolant exists.
-    pub fn get_interpolant(&self, conj: Term) -> Option<Term> {
+    pub fn get_interpolant(&self, conj: Term) -> Option<Term<'tm>> {
         let raw = unsafe { get_interpolant(self.inner, conj.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -481,7 +483,7 @@ impl Solver {
     /// Compute an interpolant constrained by the given grammar.
     ///
     /// Returns `None` if no interpolant exists.
-    pub fn get_interpolant_with_grammar(&self, conj: Term, grammar: &Grammar) -> Option<Term> {
+    pub fn get_interpolant_with_grammar(&self, conj: Term, grammar: &Grammar) -> Option<Term<'tm>> {
         let raw = unsafe { get_interpolant_with_grammar(self.inner, conj.inner, grammar.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -489,7 +491,7 @@ impl Solver {
     /// Get the next interpolant (after a previous `get_interpolant` call).
     ///
     /// Returns `None` if no further interpolant can be found.
-    pub fn get_interpolant_next(&self) -> Option<Term> {
+    pub fn get_interpolant_next(&self) -> Option<Term<'tm>> {
         let raw = unsafe { get_interpolant_next(self.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -499,7 +501,7 @@ impl Solver {
     /// Compute an abduct for the given conjecture.
     ///
     /// Returns `None` if no abduct can be found.
-    pub fn get_abduct(&self, conj: Term) -> Option<Term> {
+    pub fn get_abduct(&self, conj: Term) -> Option<Term<'tm>> {
         let raw = unsafe { get_abduct(self.inner, conj.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -507,7 +509,7 @@ impl Solver {
     /// Compute an abduct constrained by the given grammar.
     ///
     /// Returns `None` if no abduct can be found.
-    pub fn get_abduct_with_grammar(&self, conj: Term, grammar: &Grammar) -> Option<Term> {
+    pub fn get_abduct_with_grammar(&self, conj: Term, grammar: &Grammar) -> Option<Term<'tm>> {
         let raw = unsafe { get_abduct_with_grammar(self.inner, conj.inner, grammar.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -515,7 +517,7 @@ impl Solver {
     /// Get the next abduct (after a previous `get_abduct` call).
     ///
     /// Returns `None` if no further abduct can be found.
-    pub fn get_abduct_next(&self) -> Option<Term> {
+    pub fn get_abduct_next(&self) -> Option<Term<'tm>> {
         let raw = unsafe { get_abduct_next(self.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -534,13 +536,13 @@ impl Solver {
     // ── SyGuS ──────────────────────────────────────────────────────
 
     /// Declare a SyGuS variable.
-    pub fn declare_sygus_var(&mut self, symbol: &str, sort: Sort) -> Term {
+    pub fn declare_sygus_var(&mut self, symbol: &str, sort: Sort) -> Term<'tm> {
         let c = CString::new(symbol).unwrap();
         Term::from_raw(unsafe { declare_sygus_var(self.inner, c.as_ptr(), sort.inner) })
     }
 
     /// Create a SyGuS grammar from bound variables and non-terminal symbols.
-    pub fn mk_grammar(&self, bound_vars: &[Term], symbols: &[Term]) -> Grammar {
+    pub fn mk_grammar(&self, bound_vars: &[Term], symbols: &[Term]) -> Grammar<'tm> {
         let bv: Vec<cvc5_sys::Term> = bound_vars.iter().map(|t| t.inner).collect();
         let sy: Vec<cvc5_sys::Term> = symbols.iter().map(|t| t.inner).collect();
         Grammar::from_raw(unsafe {
@@ -549,7 +551,7 @@ impl Solver {
     }
 
     /// Declare a function to synthesize (SyGuS `synth-fun`).
-    pub fn synth_fun(&mut self, symbol: &str, bound_vars: &[Term], sort: Sort) -> Term {
+    pub fn synth_fun(&mut self, symbol: &str, bound_vars: &[Term], sort: Sort) -> Term<'tm> {
         let c = CString::new(symbol).unwrap();
         let raw: Vec<cvc5_sys::Term> = bound_vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
@@ -564,7 +566,7 @@ impl Solver {
         bound_vars: &[Term],
         sort: Sort,
         grammar: &Grammar,
-    ) -> Term {
+    ) -> Term<'tm> {
         let c = CString::new(symbol).unwrap();
         let raw: Vec<cvc5_sys::Term> = bound_vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
@@ -585,7 +587,7 @@ impl Solver {
     }
 
     /// Get the list of SyGuS constraints.
-    pub fn get_sygus_constraints(&self) -> Vec<Term> {
+    pub fn get_sygus_constraints(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_sygus_constraints(self.inner, &mut size) };
         (0..size)
@@ -599,7 +601,7 @@ impl Solver {
     }
 
     /// Get the list of SyGuS assumptions.
-    pub fn get_sygus_assumptions(&self) -> Vec<Term> {
+    pub fn get_sygus_assumptions(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { get_sygus_assumptions(self.inner, &mut size) };
         (0..size)
@@ -615,22 +617,22 @@ impl Solver {
     }
 
     /// Check for a synthesis solution.
-    pub fn check_synth(&mut self) -> SynthResult {
+    pub fn check_synth(&mut self) -> SynthResult<'tm> {
         SynthResult::from_raw(unsafe { check_synth(self.inner) })
     }
 
     /// Get the next synthesis solution.
-    pub fn check_synth_next(&mut self) -> SynthResult {
+    pub fn check_synth_next(&mut self) -> SynthResult<'tm> {
         SynthResult::from_raw(unsafe { check_synth_next(self.inner) })
     }
 
     /// Get the synthesis solution for a given function-to-synthesize term.
-    pub fn get_synth_solution(&self, term: Term) -> Term {
+    pub fn get_synth_solution(&self, term: Term) -> Term<'tm> {
         Term::from_raw(unsafe { get_synth_solution(self.inner, term.inner) })
     }
 
     /// Get synthesis solutions for multiple function-to-synthesize terms.
-    pub fn get_synth_solutions(&self, terms: &[Term]) -> Vec<Term> {
+    pub fn get_synth_solutions(&self, terms: &[Term]) -> Vec<Term<'tm>> {
         let raw: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
         let ptr = unsafe { get_synth_solutions(self.inner, raw.len(), raw.as_ptr()) };
         (0..terms.len())
@@ -641,7 +643,7 @@ impl Solver {
     /// Find a synthesis target of the given type.
     ///
     /// Returns `None` if the call failed.
-    pub fn find_synth(&self, target: cvc5_sys::FindSynthTarget) -> Option<Term> {
+    pub fn find_synth(&self, target: cvc5_sys::FindSynthTarget) -> Option<Term<'tm>> {
         let raw = unsafe { find_synth(self.inner, target) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -650,10 +652,10 @@ impl Solver {
     ///
     /// Returns `None` if the call failed.
     pub fn find_synth_with_grammar(
-        &self,
+        &mut self,
         target: cvc5_sys::FindSynthTarget,
         grammar: &Grammar,
-    ) -> Option<Term> {
+    ) -> Option<Term<'tm>> {
         let raw = unsafe { find_synth_with_grammar(self.inner, target, grammar.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -661,7 +663,7 @@ impl Solver {
     /// Get the next synthesis target.
     ///
     /// Returns `None` if the call failed.
-    pub fn find_synth_next(&self) -> Option<Term> {
+    pub fn find_synth_next(&self) -> Option<Term<'tm>> {
         let raw = unsafe { find_synth_next(self.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
@@ -765,7 +767,7 @@ impl Solver {
     }
 }
 
-impl Drop for Solver {
+impl Drop for Solver<'_> {
     fn drop(&mut self) {
         unsafe { delete(self.inner) }
     }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,5 +1,6 @@
 use cvc5_sys::*;
 use std::fmt;
+use std::marker::PhantomData;
 
 use crate::Datatype;
 
@@ -7,27 +8,34 @@ use crate::Datatype;
 ///
 /// Sorts represent types in the SMT solver — Boolean, Integer, Real,
 /// BitVector, Array, Datatype, etc.
-pub struct Sort {
+/// The lifetime `'tm` ties this sort to the [`TermManager`](crate::TermManager)
+/// that created it.
+pub struct Sort<'tm> {
     pub(crate) inner: cvc5_sys::Sort,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for Sort {
+impl Clone for Sort<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { sort_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for Sort {
+impl Drop for Sort<'_> {
     fn drop(&mut self) {
         unsafe { sort_release(self.inner) }
     }
 }
 
-impl Sort {
+impl<'tm> Sort<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::Sort) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Get the kind of this sort.
@@ -36,7 +44,7 @@ impl Sort {
     }
 
     /// Create a copy of this sort (increments the internal reference count).
-    pub fn copy(&self) -> Sort {
+    pub fn copy(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_copy(self.inner) })
     }
 
@@ -168,23 +176,23 @@ impl Sort {
     }
 
     /// Get the associated uninterpreted sort constructor of an instantiated sort.
-    pub fn uninterpreted_sort_constructor(&self) -> Sort {
+    pub fn uninterpreted_sort_constructor(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_get_uninterpreted_sort_constructor(self.inner) })
     }
 
     /// Get the datatype associated with a datatype sort.
-    pub fn datatype(&self) -> Datatype {
+    pub fn datatype(&self) -> Datatype<'tm> {
         Datatype::from_raw(unsafe { sort_get_datatype(self.inner) })
     }
 
     /// Instantiate a parametric sort with the given sort parameters.
-    pub fn instantiate(&self, params: &[Sort]) -> Sort {
+    pub fn instantiate(&self, params: &[Sort]) -> Sort<'tm> {
         let raw: Vec<cvc5_sys::Sort> = params.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe { sort_instantiate(self.inner, raw.len(), raw.as_ptr()) })
     }
 
     /// Get the sort parameters of an instantiated sort.
-    pub fn instantiated_parameters(&self) -> Vec<Sort> {
+    pub fn instantiated_parameters(&self) -> Vec<Sort<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { sort_get_instantiated_parameters(self.inner, &mut size) };
         (0..size)
@@ -193,12 +201,12 @@ impl Sort {
     }
 
     /// Substitute `s` with `replacement` in this sort.
-    pub fn substitute(&self, s: Sort, replacement: Sort) -> Sort {
+    pub fn substitute(&self, s: Sort, replacement: Sort) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_substitute(self.inner, s.inner, replacement.inner) })
     }
 
     /// Simultaneously substitute `sorts` with `replacements` in this sort.
-    pub fn substitute_sorts(&self, sorts: &[Sort], replacements: &[Sort]) -> Sort {
+    pub fn substitute_sorts(&self, sorts: &[Sort], replacements: &[Sort]) -> Sort<'tm> {
         let s: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
         let r: Vec<cvc5_sys::Sort> = replacements.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe {
@@ -206,124 +214,86 @@ impl Sort {
         })
     }
 
-    // -- Datatype constructor sort accessors --
-
     /// Get the arity of a datatype constructor sort.
     pub fn dt_constructor_arity(&self) -> usize {
         unsafe { sort_dt_constructor_get_arity(self.inner) }
     }
-
     /// Get the domain sorts of a datatype constructor sort.
-    pub fn dt_constructor_domain(&self) -> Vec<Sort> {
+    pub fn dt_constructor_domain(&self) -> Vec<Sort<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { sort_dt_constructor_get_domain(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
     }
-
     /// Get the codomain sort of a datatype constructor sort.
-    pub fn dt_constructor_codomain(&self) -> Sort {
+    pub fn dt_constructor_codomain(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_dt_constructor_get_codomain(self.inner) })
     }
-
-    // -- Datatype selector sort accessors --
-
     /// Get the domain sort of a datatype selector sort.
-    pub fn dt_selector_domain(&self) -> Sort {
+    pub fn dt_selector_domain(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_dt_selector_get_domain(self.inner) })
     }
-
     /// Get the codomain sort of a datatype selector sort.
-    pub fn dt_selector_codomain(&self) -> Sort {
+    pub fn dt_selector_codomain(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_dt_selector_get_codomain(self.inner) })
     }
-
-    // -- Datatype tester sort accessors --
-
     /// Get the domain sort of a datatype tester sort.
-    pub fn dt_tester_domain(&self) -> Sort {
+    pub fn dt_tester_domain(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_dt_tester_get_domain(self.inner) })
     }
-
     /// Get the codomain sort of a datatype tester sort.
-    pub fn dt_tester_codomain(&self) -> Sort {
+    pub fn dt_tester_codomain(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_dt_tester_get_codomain(self.inner) })
     }
-
-    // -- Function sort accessors --
-
     /// Get the arity of a function sort.
     pub fn fun_arity(&self) -> usize {
         unsafe { sort_fun_get_arity(self.inner) }
     }
-
     /// Get the domain sorts of a function sort.
-    pub fn fun_domain(&self) -> Vec<Sort> {
+    pub fn fun_domain(&self) -> Vec<Sort<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { sort_fun_get_domain(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
     }
-
     /// Get the codomain sort of a function sort.
-    pub fn fun_codomain(&self) -> Sort {
+    pub fn fun_codomain(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_fun_get_codomain(self.inner) })
     }
-
-    // -- Array sort accessors --
-
     /// Get the index sort of an array sort.
-    pub fn array_index_sort(&self) -> Sort {
+    pub fn array_index_sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_array_get_index_sort(self.inner) })
     }
-
     /// Get the element sort of an array sort.
-    pub fn array_element_sort(&self) -> Sort {
+    pub fn array_element_sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_array_get_element_sort(self.inner) })
     }
-
-    // -- Set / Bag / Sequence element sort --
-
     /// Get the element sort of a set sort.
-    pub fn set_element_sort(&self) -> Sort {
+    pub fn set_element_sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_set_get_element_sort(self.inner) })
     }
-
     /// Get the element sort of a bag sort.
-    pub fn bag_element_sort(&self) -> Sort {
+    pub fn bag_element_sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_bag_get_element_sort(self.inner) })
     }
-
     /// Get the element sort of a sequence sort.
-    pub fn sequence_element_sort(&self) -> Sort {
+    pub fn sequence_element_sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_sequence_get_element_sort(self.inner) })
     }
-
-    // -- Abstract sort --
-
     /// Get the kind of an abstract sort.
     pub fn abstract_kind(&self) -> cvc5_sys::SortKind {
         unsafe { sort_abstract_get_kind(self.inner) }
     }
-
-    // -- Uninterpreted sort constructor --
-
     /// Get the arity of an uninterpreted sort constructor.
     pub fn uninterpreted_sort_constructor_arity(&self) -> usize {
         unsafe { sort_uninterpreted_sort_constructor_get_arity(self.inner) }
     }
-
-    // -- Bit-vector sort --
-
     /// Get the bit-width of a bit-vector sort.
     pub fn bv_size(&self) -> u32 {
         unsafe { sort_bv_get_size(self.inner) }
     }
-
-    // -- Finite field sort --
-
     /// Get the size (modulus) of a finite field sort as a string.
     pub fn ff_size(&self) -> String {
         unsafe {
@@ -331,51 +301,37 @@ impl Sort {
             std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned()
         }
     }
-
-    // -- Floating-point sort --
-
     /// Get the exponent size of a floating-point sort.
     pub fn fp_exponent_size(&self) -> u32 {
         unsafe { sort_fp_get_exp_size(self.inner) }
     }
-
     /// Get the significand size of a floating-point sort.
     pub fn fp_significand_size(&self) -> u32 {
         unsafe { sort_fp_get_sig_size(self.inner) }
     }
-
-    // -- Datatype sort --
-
     /// Get the arity of a datatype sort.
     pub fn dt_arity(&self) -> usize {
         unsafe { sort_dt_get_arity(self.inner) }
     }
-
-    // -- Tuple sort --
-
     /// Get the length (number of elements) of a tuple sort.
     pub fn tuple_length(&self) -> usize {
         unsafe { sort_tuple_get_length(self.inner) }
     }
-
     /// Get the element sorts of a tuple sort.
-    pub fn tuple_element_sorts(&self) -> Vec<Sort> {
+    pub fn tuple_element_sorts(&self) -> Vec<Sort<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { sort_tuple_get_element_sorts(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
     }
-
-    // -- Nullable sort --
-
     /// Get the element sort of a nullable sort.
-    pub fn nullable_element_sort(&self) -> Sort {
+    pub fn nullable_element_sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { sort_nullable_get_element_sort(self.inner) })
     }
 }
 
-impl fmt::Display for Sort {
+impl fmt::Display for Sort<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { sort_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
@@ -383,34 +339,34 @@ impl fmt::Display for Sort {
     }
 }
 
-impl fmt::Debug for Sort {
+impl fmt::Debug for Sort<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Sort({self})")
     }
 }
 
-impl PartialEq for Sort {
+impl PartialEq for Sort<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { sort_is_equal(self.inner, other.inner) }
     }
 }
 
-impl Eq for Sort {}
+impl Eq for Sort<'_> {}
 
-impl PartialOrd for Sort {
+impl PartialOrd for Sort<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for Sort {
+impl Ord for Sort<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         let c = unsafe { sort_compare(self.inner, other.inner) };
         c.cmp(&0)
     }
 }
 
-impl std::hash::Hash for Sort {
+impl std::hash::Hash for Sort<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { sort_hash(self.inner) }.hash(state);
     }

--- a/src/synth_result.rs
+++ b/src/synth_result.rs
@@ -1,28 +1,34 @@
 use cvc5_sys::*;
 use std::fmt;
+use std::marker::PhantomData;
 
 /// The result of a synthesis query (SyGuS).
-pub struct SynthResult {
+pub struct SynthResult<'tm> {
     pub(crate) inner: cvc5_sys::SynthResult,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for SynthResult {
+impl Clone for SynthResult<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { synth_result_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for SynthResult {
+impl Drop for SynthResult<'_> {
     fn drop(&mut self) {
         unsafe { synth_result_release(self.inner) }
     }
 }
 
-impl SynthResult {
+impl<'tm> SynthResult<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::SynthResult) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Return `true` if this is a null (uninitialized) synthesis result.
@@ -31,7 +37,7 @@ impl SynthResult {
     }
 
     /// Create a copy of this synthesis result (increments the internal reference count).
-    pub fn copy(&self) -> SynthResult {
+    pub fn copy(&self) -> SynthResult<'tm> {
         SynthResult::from_raw(unsafe { synth_result_copy(self.inner) })
     }
 
@@ -56,7 +62,7 @@ impl SynthResult {
     }
 }
 
-impl fmt::Display for SynthResult {
+impl fmt::Display for SynthResult<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { synth_result_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
@@ -64,21 +70,21 @@ impl fmt::Display for SynthResult {
     }
 }
 
-impl PartialEq for SynthResult {
+impl PartialEq for SynthResult<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { synth_result_is_equal(self.inner, other.inner) }
     }
 }
 
-impl Eq for SynthResult {}
+impl Eq for SynthResult<'_> {}
 
-impl std::hash::Hash for SynthResult {
+impl std::hash::Hash for SynthResult<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { synth_result_hash(self.inner) }.hash(state);
     }
 }
 
-impl fmt::Debug for SynthResult {
+impl fmt::Debug for SynthResult<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SynthResult({self})")
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,32 +1,40 @@
 use cvc5_sys::*;
 use std::fmt;
+use std::marker::PhantomData;
 
 use crate::{Op, Sort};
 
 /// A cvc5 term (expression or formula).
 ///
 /// Terms are the main building blocks for assertions, queries, and models.
-pub struct Term {
+/// The lifetime `'tm` ties this term to the [`TermManager`](crate::TermManager)
+/// that created it, preventing use-after-free.
+pub struct Term<'tm> {
     pub(crate) inner: cvc5_sys::Term,
+    pub(crate) _phantom: PhantomData<&'tm ()>,
 }
 
-impl Clone for Term {
+impl Clone for Term<'_> {
     fn clone(&self) -> Self {
         Self {
             inner: unsafe { term_copy(self.inner) },
+            _phantom: PhantomData,
         }
     }
 }
 
-impl Drop for Term {
+impl Drop for Term<'_> {
     fn drop(&mut self) {
         unsafe { term_release(self.inner) }
     }
 }
 
-impl Term {
+impl<'tm> Term<'tm> {
     pub(crate) fn from_raw(raw: cvc5_sys::Term) -> Self {
-        Self { inner: raw }
+        Self {
+            inner: raw,
+            _phantom: PhantomData,
+        }
     }
 
     /// Get the kind of this term.
@@ -35,7 +43,7 @@ impl Term {
     }
 
     /// Create a copy of this term (increments the internal reference count).
-    pub fn copy(&self) -> Term {
+    pub fn copy(&self) -> Term<'tm> {
         Term::from_raw(unsafe { term_copy(self.inner) })
     }
 
@@ -45,7 +53,7 @@ impl Term {
     }
 
     /// Get the sort of this term.
-    pub fn sort(&self) -> Sort {
+    pub fn sort(&self) -> Sort<'tm> {
         Sort::from_raw(unsafe { term_get_sort(self.inner) })
     }
 
@@ -60,7 +68,7 @@ impl Term {
     }
 
     /// Get the child at the given index.
-    pub fn child(&self, index: usize) -> Term {
+    pub fn child(&self, index: usize) -> Term<'tm> {
         Term::from_raw(unsafe { term_get_child(self.inner, index) })
     }
 
@@ -83,17 +91,17 @@ impl Term {
     }
 
     /// Get the operator associated with this term.
-    pub fn op(&self) -> Op {
+    pub fn op(&self) -> Op<'tm> {
         Op::from_raw(unsafe { term_get_op(self.inner) })
     }
 
     /// Substitute `t` with `replacement` in this term.
-    pub fn substitute_term(&self, t: Term, replacement: Term) -> Term {
+    pub fn substitute_term(&self, t: Term, replacement: Term) -> Term<'tm> {
         Term::from_raw(unsafe { term_substitute_term(self.inner, t.inner, replacement.inner) })
     }
 
     /// Simultaneously substitute `terms` with `replacements` in this term.
-    pub fn substitute_terms(&self, terms: &[Term], replacements: &[Term]) -> Term {
+    pub fn substitute_terms(&self, terms: &[Term], replacements: &[Term]) -> Term<'tm> {
         let t: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
         let r: Vec<cvc5_sys::Term> = replacements.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
@@ -239,7 +247,7 @@ impl Term {
         unsafe { term_is_const_array(self.inner) }
     }
     /// Get the base (default) value of a constant array.
-    pub fn const_array_base(&self) -> Term {
+    pub fn const_array_base(&self) -> Term<'tm> {
         Term::from_raw(unsafe { term_get_const_array_base(self.inner) })
     }
 
@@ -287,7 +295,7 @@ impl Term {
         unsafe { term_is_tuple_value(self.inner) }
     }
     /// Get the elements of a tuple value.
-    pub fn tuple_value(&self) -> Vec<Term> {
+    pub fn tuple_value(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { term_get_tuple_value(self.inner, &mut size) };
         (0..size)
@@ -329,7 +337,7 @@ impl Term {
         unsafe { term_is_fp_value(self.inner) }
     }
     /// Get the floating-point value as `(exponent_width, significand_width, bit_vector_value)`.
-    pub fn fp_value(&self) -> (u32, u32, Term) {
+    pub fn fp_value(&self) -> (u32, u32, Term<'tm>) {
         let (mut ew, mut sw) = (0u32, 0u32);
         let mut val = std::ptr::null_mut();
         unsafe { term_get_fp_value(self.inner, &mut ew, &mut sw, &mut val) };
@@ -341,7 +349,7 @@ impl Term {
         unsafe { term_is_set_value(self.inner) }
     }
     /// Get the elements of a set value.
-    pub fn set_value(&self) -> Vec<Term> {
+    pub fn set_value(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { term_get_set_value(self.inner, &mut size) };
         (0..size)
@@ -354,7 +362,7 @@ impl Term {
         unsafe { term_is_sequence_value(self.inner) }
     }
     /// Get the elements of a sequence value.
-    pub fn sequence_value(&self) -> Vec<Term> {
+    pub fn sequence_value(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { term_get_sequence_value(self.inner, &mut size) };
         (0..size)
@@ -367,7 +375,7 @@ impl Term {
         unsafe { term_is_cardinality_constraint(self.inner) }
     }
     /// Get the sort and upper bound of a cardinality constraint.
-    pub fn cardinality_constraint(&self) -> (Sort, u32) {
+    pub fn cardinality_constraint(&self) -> (Sort<'tm>, u32) {
         let mut sort = std::ptr::null_mut();
         let mut upper = 0u32;
         unsafe { term_get_cardinality_constraint(self.inner, &mut sort, &mut upper) };
@@ -379,17 +387,17 @@ impl Term {
         unsafe { term_is_real_algebraic_number(self.inner) }
     }
     /// Get the defining polynomial of a real algebraic number in terms of variable `v`.
-    pub fn real_algebraic_number_defining_polynomial(&self, v: Term) -> Term {
+    pub fn real_algebraic_number_defining_polynomial(&self, v: Term) -> Term<'tm> {
         Term::from_raw(unsafe {
             term_get_real_algebraic_number_defining_polynomial(self.inner, v.inner)
         })
     }
     /// Get the lower bound of the isolating interval of a real algebraic number.
-    pub fn real_algebraic_number_lower_bound(&self) -> Term {
+    pub fn real_algebraic_number_lower_bound(&self) -> Term<'tm> {
         Term::from_raw(unsafe { term_get_real_algebraic_number_lower_bound(self.inner) })
     }
     /// Get the upper bound of the isolating interval of a real algebraic number.
-    pub fn real_algebraic_number_upper_bound(&self) -> Term {
+    pub fn real_algebraic_number_upper_bound(&self) -> Term<'tm> {
         Term::from_raw(unsafe { term_get_real_algebraic_number_upper_bound(self.inner) })
     }
 
@@ -402,7 +410,7 @@ impl Term {
         unsafe { term_get_skolem_id(self.inner) }
     }
     /// Get the indices of this Skolem term.
-    pub fn skolem_indices(&self) -> Vec<Term> {
+    pub fn skolem_indices(&self) -> Vec<Term<'tm>> {
         let mut size = 0usize;
         let ptr = unsafe { term_get_skolem_indices(self.inner, &mut size) };
         (0..size)
@@ -411,7 +419,7 @@ impl Term {
     }
 }
 
-impl fmt::Display for Term {
+impl fmt::Display for Term<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = unsafe { term_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
@@ -419,34 +427,34 @@ impl fmt::Display for Term {
     }
 }
 
-impl fmt::Debug for Term {
+impl fmt::Debug for Term<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Term({self})")
     }
 }
 
-impl PartialEq for Term {
+impl PartialEq for Term<'_> {
     fn eq(&self, other: &Self) -> bool {
         unsafe { term_is_equal(self.inner, other.inner) }
     }
 }
 
-impl Eq for Term {}
+impl Eq for Term<'_> {}
 
-impl PartialOrd for Term {
+impl PartialOrd for Term<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for Term {
+impl Ord for Term<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         let c = unsafe { term_compare(self.inner, other.inner) };
         c.cmp(&0)
     }
 }
 
-impl std::hash::Hash for Term {
+impl std::hash::Hash for Term<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe { term_hash(self.inner) }.hash(state);
     }

--- a/src/term_manager.rs
+++ b/src/term_manager.rs
@@ -9,6 +9,9 @@ use crate::{DatatypeConstructorDecl, DatatypeDecl, Op, Sort, Statistics, Term};
 ///
 /// Uses interior mutability (`Rc<RefCell<…>>`) so the manager can be
 /// cheaply cloned and shared while still allowing mutation through `&self`.
+///
+/// All objects created by a `TermManager` carry a lifetime tied to the
+/// manager, ensuring they cannot outlive it.
 #[derive(Clone)]
 pub struct TermManager {
     pub(crate) inner: Rc<RefCell<*mut cvc5_sys::TermManager>>,
@@ -35,58 +38,58 @@ impl TermManager {
     // ── Sort creation ──────────────────────────────────────────────
 
     /// Get the Boolean sort.
-    pub fn boolean_sort(&self) -> Sort {
+    pub fn boolean_sort(&self) -> Sort<'_> {
         Sort::from_raw(unsafe { get_boolean_sort(self.ptr()) })
     }
     /// Get the Integer sort.
-    pub fn integer_sort(&self) -> Sort {
+    pub fn integer_sort(&self) -> Sort<'_> {
         Sort::from_raw(unsafe { get_integer_sort(self.ptr()) })
     }
     /// Get the Real sort.
-    pub fn real_sort(&self) -> Sort {
+    pub fn real_sort(&self) -> Sort<'_> {
         Sort::from_raw(unsafe { get_real_sort(self.ptr()) })
     }
     /// Get the String sort.
-    pub fn string_sort(&self) -> Sort {
+    pub fn string_sort(&self) -> Sort<'_> {
         Sort::from_raw(unsafe { get_string_sort(self.ptr()) })
     }
     /// Get the RegExp sort.
-    pub fn regexp_sort(&self) -> Sort {
+    pub fn regexp_sort(&self) -> Sort<'_> {
         Sort::from_raw(unsafe { get_regexp_sort(self.ptr()) })
     }
     /// Get the rounding mode sort.
-    pub fn rm_sort(&self) -> Sort {
+    pub fn rm_sort(&self) -> Sort<'_> {
         Sort::from_raw(unsafe { get_rm_sort(self.ptr()) })
     }
 
     /// Create an array sort with the given index and element sorts.
-    pub fn mk_array_sort(&self, index: Sort, elem: Sort) -> Sort {
+    pub fn mk_array_sort(&self, index: Sort, elem: Sort) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_array_sort(self.ptr_mut(), index.inner, elem.inner) })
     }
 
     /// Create a bit-vector sort of the given bit-width.
-    pub fn mk_bv_sort(&self, size: u32) -> Sort {
+    pub fn mk_bv_sort(&self, size: u32) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_bv_sort(self.ptr_mut(), size) })
     }
 
     /// Create a floating-point sort with the given exponent and significand sizes.
-    pub fn mk_fp_sort(&self, exp: u32, sig: u32) -> Sort {
+    pub fn mk_fp_sort(&self, exp: u32, sig: u32) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_fp_sort(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a finite field sort of the given size (modulus) in the given base.
-    pub fn mk_ff_sort(&self, size: &str, base: u32) -> Sort {
+    pub fn mk_ff_sort(&self, size: &str, base: u32) -> Sort<'_> {
         let c = CString::new(size).unwrap();
         Sort::from_raw(unsafe { mk_ff_sort(self.ptr_mut(), c.as_ptr(), base) })
     }
 
     /// Create a datatype sort from a datatype declaration.
-    pub fn mk_dt_sort(&self, decl: &DatatypeDecl) -> Sort {
+    pub fn mk_dt_sort(&self, decl: &DatatypeDecl) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_dt_sort(self.ptr_mut(), decl.inner) })
     }
 
     /// Create mutually recursive datatype sorts from declarations.
-    pub fn mk_dt_sorts(&self, decls: &[DatatypeDecl]) -> Vec<Sort> {
+    pub fn mk_dt_sorts(&self, decls: &[DatatypeDecl]) -> Vec<Sort<'_>> {
         let raw: Vec<cvc5_sys::DatatypeDecl> = decls.iter().map(|d| d.inner).collect();
         let ptr = unsafe { mk_dt_sorts(self.ptr_mut(), raw.len(), raw.as_ptr()) };
         (0..decls.len())
@@ -95,7 +98,7 @@ impl TermManager {
     }
 
     /// Create a function sort with the given domain and codomain sorts.
-    pub fn mk_fun_sort(&self, domain: &[Sort], codomain: Sort) -> Sort {
+    pub fn mk_fun_sort(&self, domain: &[Sort], codomain: Sort) -> Sort<'_> {
         let raw: Vec<cvc5_sys::Sort> = domain.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe {
             mk_fun_sort(self.ptr_mut(), raw.len(), raw.as_ptr(), codomain.inner)
@@ -103,19 +106,19 @@ impl TermManager {
     }
 
     /// Create a sort parameter with the given symbol.
-    pub fn mk_param_sort(&self, symbol: &str) -> Sort {
+    pub fn mk_param_sort(&self, symbol: &str) -> Sort<'_> {
         let c = CString::new(symbol).unwrap();
         Sort::from_raw(unsafe { mk_param_sort(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a predicate sort (function sort with Boolean codomain).
-    pub fn mk_predicate_sort(&self, sorts: &[Sort]) -> Sort {
+    pub fn mk_predicate_sort(&self, sorts: &[Sort]) -> Sort<'_> {
         let raw: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe { mk_predicate_sort(self.ptr_mut(), raw.len(), raw.as_ptr()) })
     }
 
     /// Create a record sort with the given field names and sorts.
-    pub fn mk_record_sort(&self, names: &[&str], sorts: &[Sort]) -> Sort {
+    pub fn mk_record_sort(&self, names: &[&str], sorts: &[Sort]) -> Sort<'_> {
         let cnames: Vec<CString> = names.iter().map(|n| CString::new(*n).unwrap()).collect();
         let mut ptrs: Vec<*const std::ffi::c_char> = cnames.iter().map(|c| c.as_ptr()).collect();
         let raw: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
@@ -125,44 +128,44 @@ impl TermManager {
     }
 
     /// Create a set sort with the given element sort.
-    pub fn mk_set_sort(&self, elem: Sort) -> Sort {
+    pub fn mk_set_sort(&self, elem: Sort) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_set_sort(self.ptr_mut(), elem.inner) })
     }
 
     /// Create a bag sort with the given element sort.
-    pub fn mk_bag_sort(&self, elem: Sort) -> Sort {
+    pub fn mk_bag_sort(&self, elem: Sort) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_bag_sort(self.ptr_mut(), elem.inner) })
     }
 
     /// Create a sequence sort with the given element sort.
-    pub fn mk_sequence_sort(&self, elem: Sort) -> Sort {
+    pub fn mk_sequence_sort(&self, elem: Sort) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_sequence_sort(self.ptr_mut(), elem.inner) })
     }
 
     /// Create an abstract sort of the given sort kind.
-    pub fn mk_abstract_sort(&self, k: cvc5_sys::SortKind) -> Sort {
+    pub fn mk_abstract_sort(&self, k: cvc5_sys::SortKind) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_abstract_sort(self.ptr_mut(), k) })
     }
 
     /// Create a named uninterpreted sort.
-    pub fn mk_uninterpreted_sort(&self, name: &str) -> Sort {
+    pub fn mk_uninterpreted_sort(&self, name: &str) -> Sort<'_> {
         let c = CString::new(name).unwrap();
         Sort::from_raw(unsafe { mk_uninterpreted_sort(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create an anonymous uninterpreted sort (no symbol).
-    pub fn mk_anonymous_uninterpreted_sort(&self) -> Sort {
+    pub fn mk_anonymous_uninterpreted_sort(&self) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_uninterpreted_sort(self.ptr_mut(), std::ptr::null()) })
     }
 
     /// Create an unresolved datatype sort placeholder for mutual recursion.
-    pub fn mk_unresolved_dt_sort(&self, symbol: &str, arity: usize) -> Sort {
+    pub fn mk_unresolved_dt_sort(&self, symbol: &str, arity: usize) -> Sort<'_> {
         let c = CString::new(symbol).unwrap();
         Sort::from_raw(unsafe { mk_unresolved_dt_sort(self.ptr_mut(), c.as_ptr(), arity) })
     }
 
     /// Create an uninterpreted sort constructor of the given arity.
-    pub fn mk_uninterpreted_sort_constructor_sort(&self, arity: usize, symbol: &str) -> Sort {
+    pub fn mk_uninterpreted_sort_constructor_sort(&self, arity: usize, symbol: &str) -> Sort<'_> {
         let c = CString::new(symbol).unwrap();
         Sort::from_raw(unsafe {
             mk_uninterpreted_sort_constructor_sort(self.ptr_mut(), arity, c.as_ptr())
@@ -170,32 +173,32 @@ impl TermManager {
     }
 
     /// Create an anonymous uninterpreted sort constructor of the given arity.
-    pub fn mk_anonymous_uninterpreted_sort_constructor_sort(&self, arity: usize) -> Sort {
+    pub fn mk_anonymous_uninterpreted_sort_constructor_sort(&self, arity: usize) -> Sort<'_> {
         Sort::from_raw(unsafe {
             mk_uninterpreted_sort_constructor_sort(self.ptr_mut(), arity, std::ptr::null())
         })
     }
 
     /// Create a tuple sort with the given element sorts.
-    pub fn mk_tuple_sort(&self, sorts: &[Sort]) -> Sort {
+    pub fn mk_tuple_sort(&self, sorts: &[Sort]) -> Sort<'_> {
         let raw: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe { mk_tuple_sort(self.ptr_mut(), raw.len(), raw.as_ptr()) })
     }
 
     /// Create a nullable sort wrapping the given sort.
-    pub fn mk_nullable_sort(&self, sort: Sort) -> Sort {
+    pub fn mk_nullable_sort(&self, sort: Sort) -> Sort<'_> {
         Sort::from_raw(unsafe { mk_nullable_sort(self.ptr_mut(), sort.inner) })
     }
 
     // ── Operator creation ──────────────────────────────────────────
 
     /// Create an indexed operator with the given kind and integer indices.
-    pub fn mk_op(&self, kind: cvc5_sys::Kind, indices: &[u32]) -> Op {
+    pub fn mk_op(&self, kind: cvc5_sys::Kind, indices: &[u32]) -> Op<'_> {
         Op::from_raw(unsafe { mk_op(self.ptr_mut(), kind, indices.len(), indices.as_ptr()) })
     }
 
     /// Create an indexed operator with the given kind and string argument.
-    pub fn mk_op_from_str(&self, kind: cvc5_sys::Kind, arg: &str) -> Op {
+    pub fn mk_op_from_str(&self, kind: cvc5_sys::Kind, arg: &str) -> Op<'_> {
         let c = CString::new(arg).unwrap();
         Op::from_raw(unsafe { mk_op_from_str(self.ptr_mut(), kind, c.as_ptr()) })
     }
@@ -203,13 +206,13 @@ impl TermManager {
     // ── Term creation ──────────────────────────────────────────────
 
     /// Create a term with the given kind and children.
-    pub fn mk_term(&self, kind: cvc5_sys::Kind, children: &[Term]) -> Term {
+    pub fn mk_term(&self, kind: cvc5_sys::Kind, children: &[Term]) -> Term<'_> {
         let raw: Vec<cvc5_sys::Term> = children.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe { mk_term(self.ptr_mut(), kind, raw.len(), raw.as_ptr()) })
     }
 
     /// Create a term from an operator and children.
-    pub fn mk_term_from_op(&self, op: Op, children: &[Term]) -> Term {
+    pub fn mk_term_from_op(&self, op: Op, children: &[Term]) -> Term<'_> {
         let raw: Vec<cvc5_sys::Term> = children.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
             mk_term_from_op(self.ptr_mut(), op.inner, raw.len(), raw.as_ptr())
@@ -217,44 +220,44 @@ impl TermManager {
     }
 
     /// Create a tuple term from the given elements.
-    pub fn mk_tuple(&self, terms: &[Term]) -> Term {
+    pub fn mk_tuple(&self, terms: &[Term]) -> Term<'_> {
         let raw: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe { mk_tuple(self.ptr_mut(), raw.len(), raw.as_ptr()) })
     }
 
     /// Create a nullable term wrapping the given value.
-    pub fn mk_nullable_some(&self, term: Term) -> Term {
+    pub fn mk_nullable_some(&self, term: Term) -> Term<'_> {
         Term::from_raw(unsafe { mk_nullable_some(self.ptr_mut(), term.inner) })
     }
 
     /// Extract the value from a nullable term.
-    pub fn mk_nullable_val(&self, term: Term) -> Term {
+    pub fn mk_nullable_val(&self, term: Term) -> Term<'_> {
         Term::from_raw(unsafe { mk_nullable_val(self.ptr_mut(), term.inner) })
     }
 
     /// Create a term testing whether a nullable is null.
-    pub fn mk_nullable_is_null(&self, term: Term) -> Term {
+    pub fn mk_nullable_is_null(&self, term: Term) -> Term<'_> {
         Term::from_raw(unsafe { mk_nullable_is_null(self.ptr_mut(), term.inner) })
     }
 
     /// Create a term testing whether a nullable has a value.
-    pub fn mk_nullable_is_some(&self, term: Term) -> Term {
+    pub fn mk_nullable_is_some(&self, term: Term) -> Term<'_> {
         Term::from_raw(unsafe { mk_nullable_is_some(self.ptr_mut(), term.inner) })
     }
 
     /// Create a null nullable term of the given sort.
-    pub fn mk_nullable_null(&self, sort: Sort) -> Term {
+    pub fn mk_nullable_null(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_nullable_null(self.ptr_mut(), sort.inner) })
     }
 
     /// Lift an operator over nullable arguments.
-    pub fn mk_nullable_lift(&self, kind: cvc5_sys::Kind, args: &[Term]) -> Term {
+    pub fn mk_nullable_lift(&self, kind: cvc5_sys::Kind, args: &[Term]) -> Term<'_> {
         let raw: Vec<cvc5_sys::Term> = args.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe { mk_nullable_lift(self.ptr_mut(), kind, raw.len(), raw.as_ptr()) })
     }
 
     /// Create a Skolem term with the given identifier and indices.
-    pub fn mk_skolem(&self, id: cvc5_sys::SkolemId, indices: &[Term]) -> Term {
+    pub fn mk_skolem(&self, id: cvc5_sys::SkolemId, indices: &[Term]) -> Term<'_> {
         let raw: Vec<cvc5_sys::Term> = indices.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe { mk_skolem(self.ptr_mut(), id, raw.len(), raw.as_ptr()) })
     }
@@ -267,162 +270,162 @@ impl TermManager {
     // ── Constants ──────────────────────────────────────────────────
 
     /// Create the Boolean constant `true`.
-    pub fn mk_true(&self) -> Term {
+    pub fn mk_true(&self) -> Term<'_> {
         Term::from_raw(unsafe { mk_true(self.ptr_mut()) })
     }
     /// Create the Boolean constant `false`.
-    pub fn mk_false(&self) -> Term {
+    pub fn mk_false(&self) -> Term<'_> {
         Term::from_raw(unsafe { mk_false(self.ptr_mut()) })
     }
     /// Create a Boolean constant from a Rust `bool`.
-    pub fn mk_boolean(&self, val: bool) -> Term {
+    pub fn mk_boolean(&self, val: bool) -> Term<'_> {
         Term::from_raw(unsafe { mk_boolean(self.ptr_mut(), val) })
     }
     /// Create the constant pi.
-    pub fn mk_pi(&self) -> Term {
+    pub fn mk_pi(&self) -> Term<'_> {
         Term::from_raw(unsafe { mk_pi(self.ptr_mut()) })
     }
 
     /// Create an integer constant from an `i64`.
-    pub fn mk_integer(&self, val: i64) -> Term {
+    pub fn mk_integer(&self, val: i64) -> Term<'_> {
         Term::from_raw(unsafe { mk_integer_int64(self.ptr_mut(), val) })
     }
 
     /// Create an integer constant from a decimal string.
-    pub fn mk_integer_from_str(&self, s: &str) -> Term {
+    pub fn mk_integer_from_str(&self, s: &str) -> Term<'_> {
         let c = CString::new(s).unwrap();
         Term::from_raw(unsafe { mk_integer(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a real constant from an `i64`.
-    pub fn mk_real(&self, val: i64) -> Term {
+    pub fn mk_real(&self, val: i64) -> Term<'_> {
         Term::from_raw(unsafe { mk_real_int64(self.ptr_mut(), val) })
     }
 
     /// Create a real constant from a decimal string.
-    pub fn mk_real_from_str(&self, s: &str) -> Term {
+    pub fn mk_real_from_str(&self, s: &str) -> Term<'_> {
         let c = CString::new(s).unwrap();
         Term::from_raw(unsafe { mk_real(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a real constant from a numerator and denominator.
-    pub fn mk_real_from_rational(&self, num: i64, den: i64) -> Term {
+    pub fn mk_real_from_rational(&self, num: i64, den: i64) -> Term<'_> {
         Term::from_raw(unsafe { mk_real_num_den(self.ptr_mut(), num, den) })
     }
 
     /// Create the regular expression that matches everything (`re.all`).
-    pub fn mk_regexp_all(&self) -> Term {
+    pub fn mk_regexp_all(&self) -> Term<'_> {
         Term::from_raw(unsafe { mk_regexp_all(self.ptr_mut()) })
     }
     /// Create the regular expression that matches any single character.
-    pub fn mk_regexp_allchar(&self) -> Term {
+    pub fn mk_regexp_allchar(&self) -> Term<'_> {
         Term::from_raw(unsafe { mk_regexp_allchar(self.ptr_mut()) })
     }
     /// Create the regular expression that matches nothing (`re.none`).
-    pub fn mk_regexp_none(&self) -> Term {
+    pub fn mk_regexp_none(&self) -> Term<'_> {
         Term::from_raw(unsafe { mk_regexp_none(self.ptr_mut()) })
     }
 
     /// Create an empty set of the given sort.
-    pub fn mk_empty_set(&self, sort: Sort) -> Term {
+    pub fn mk_empty_set(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_empty_set(self.ptr_mut(), sort.inner) })
     }
 
     /// Create an empty bag of the given sort.
-    pub fn mk_empty_bag(&self, sort: Sort) -> Term {
+    pub fn mk_empty_bag(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_empty_bag(self.ptr_mut(), sort.inner) })
     }
 
     /// Create the separation logic empty heap constraint.
-    pub fn mk_sep_emp(&self) -> Term {
+    pub fn mk_sep_emp(&self) -> Term<'_> {
         Term::from_raw(unsafe { mk_sep_emp(self.ptr_mut()) })
     }
 
     /// Create the separation logic nil term of the given sort.
-    pub fn mk_sep_nil(&self, sort: Sort) -> Term {
+    pub fn mk_sep_nil(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_sep_nil(self.ptr_mut(), sort.inner) })
     }
 
     /// Create a string constant. If `use_esc_seq` is true, process escape sequences.
-    pub fn mk_string(&self, s: &str, use_esc_seq: bool) -> Term {
+    pub fn mk_string(&self, s: &str, use_esc_seq: bool) -> Term<'_> {
         let c = CString::new(s).unwrap();
         Term::from_raw(unsafe { mk_string(self.ptr_mut(), c.as_ptr(), use_esc_seq) })
     }
 
     /// Create an empty sequence of the given element sort.
-    pub fn mk_empty_sequence(&self, sort: Sort) -> Term {
+    pub fn mk_empty_sequence(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_empty_sequence(self.ptr_mut(), sort.inner) })
     }
 
     /// Create the universe set of the given sort.
-    pub fn mk_universe_set(&self, sort: Sort) -> Term {
+    pub fn mk_universe_set(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_universe_set(self.ptr_mut(), sort.inner) })
     }
 
     /// Create a bit-vector constant of the given size and value.
-    pub fn mk_bv(&self, size: u32, val: u64) -> Term {
+    pub fn mk_bv(&self, size: u32, val: u64) -> Term<'_> {
         Term::from_raw(unsafe { mk_bv_uint64(self.ptr_mut(), size, val) })
     }
 
     /// Create a bit-vector constant from a string in the given base (2, 10, or 16).
-    pub fn mk_bv_from_str(&self, size: u32, s: &str, base: u32) -> Term {
+    pub fn mk_bv_from_str(&self, size: u32, s: &str, base: u32) -> Term<'_> {
         let c = CString::new(s).unwrap();
         Term::from_raw(unsafe { mk_bv(self.ptr_mut(), size, c.as_ptr(), base) })
     }
 
     /// Create a finite field element from a string value in the given base.
-    pub fn mk_ff_elem(&self, value: &str, sort: Sort, base: u32) -> Term {
+    pub fn mk_ff_elem(&self, value: &str, sort: Sort, base: u32) -> Term<'_> {
         let c = CString::new(value).unwrap();
         Term::from_raw(unsafe { mk_ff_elem(self.ptr_mut(), c.as_ptr(), sort.inner, base) })
     }
 
     /// Create a constant array where every element is `val`.
-    pub fn mk_const_array(&self, sort: Sort, val: Term) -> Term {
+    pub fn mk_const_array(&self, sort: Sort, val: Term) -> Term<'_> {
         Term::from_raw(unsafe { mk_const_array(self.ptr_mut(), sort.inner, val.inner) })
     }
 
     /// Create a positive infinity floating-point constant.
-    pub fn mk_fp_pos_inf(&self, exp: u32, sig: u32) -> Term {
+    pub fn mk_fp_pos_inf(&self, exp: u32, sig: u32) -> Term<'_> {
         Term::from_raw(unsafe { mk_fp_pos_inf(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a negative infinity floating-point constant.
-    pub fn mk_fp_neg_inf(&self, exp: u32, sig: u32) -> Term {
+    pub fn mk_fp_neg_inf(&self, exp: u32, sig: u32) -> Term<'_> {
         Term::from_raw(unsafe { mk_fp_neg_inf(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a NaN floating-point constant.
-    pub fn mk_fp_nan(&self, exp: u32, sig: u32) -> Term {
+    pub fn mk_fp_nan(&self, exp: u32, sig: u32) -> Term<'_> {
         Term::from_raw(unsafe { mk_fp_nan(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a positive zero floating-point constant.
-    pub fn mk_fp_pos_zero(&self, exp: u32, sig: u32) -> Term {
+    pub fn mk_fp_pos_zero(&self, exp: u32, sig: u32) -> Term<'_> {
         Term::from_raw(unsafe { mk_fp_pos_zero(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a negative zero floating-point constant.
-    pub fn mk_fp_neg_zero(&self, exp: u32, sig: u32) -> Term {
+    pub fn mk_fp_neg_zero(&self, exp: u32, sig: u32) -> Term<'_> {
         Term::from_raw(unsafe { mk_fp_neg_zero(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a rounding mode constant.
-    pub fn mk_rm(&self, rm: cvc5_sys::RoundingMode) -> Term {
+    pub fn mk_rm(&self, rm: cvc5_sys::RoundingMode) -> Term<'_> {
         Term::from_raw(unsafe { mk_rm(self.ptr_mut(), rm) })
     }
 
     /// Create a floating-point constant from a bit-vector value.
-    pub fn mk_fp(&self, exp: u32, sig: u32, val: Term) -> Term {
+    pub fn mk_fp(&self, exp: u32, sig: u32, val: Term) -> Term<'_> {
         Term::from_raw(unsafe { mk_fp(self.ptr_mut(), exp, sig, val.inner) })
     }
 
     /// Create a floating-point constant from IEEE 754 sign, exponent, and significand bit-vectors.
-    pub fn mk_fp_from_ieee(&self, sign: Term, exp: Term, sig: Term) -> Term {
+    pub fn mk_fp_from_ieee(&self, sign: Term, exp: Term, sig: Term) -> Term<'_> {
         Term::from_raw(unsafe { mk_fp_from_ieee(self.ptr_mut(), sign.inner, exp.inner, sig.inner) })
     }
 
     /// Create a cardinality constraint on the given sort.
-    pub fn mk_cardinality_constraint(&self, sort: Sort, upper_bound: u32) -> Term {
+    pub fn mk_cardinality_constraint(&self, sort: Sort, upper_bound: u32) -> Term<'_> {
         Term::from_raw(unsafe {
             mk_cardinality_constraint(self.ptr_mut(), sort.inner, upper_bound)
         })
@@ -431,37 +434,37 @@ impl TermManager {
     // ── Variables ──────────────────────────────────────────────────
 
     /// Create a named constant (free variable) of the given sort.
-    pub fn mk_const(&self, sort: Sort, name: &str) -> Term {
+    pub fn mk_const(&self, sort: Sort, name: &str) -> Term<'_> {
         let c = CString::new(name).unwrap();
         Term::from_raw(unsafe { mk_const(self.ptr_mut(), sort.inner, c.as_ptr()) })
     }
 
     /// Create an anonymous constant (free variable) of the given sort.
-    pub fn mk_anonymous_const(&self, sort: Sort) -> Term {
+    pub fn mk_anonymous_const(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_const(self.ptr_mut(), sort.inner, std::ptr::null()) })
     }
 
     /// Create a bound variable of the given sort.
-    pub fn mk_var(&self, sort: Sort, name: &str) -> Term {
+    pub fn mk_var(&self, sort: Sort, name: &str) -> Term<'_> {
         let c = CString::new(name).unwrap();
         Term::from_raw(unsafe { mk_var(self.ptr_mut(), sort.inner, c.as_ptr()) })
     }
 
     /// Create an anonymous bound variable of the given sort.
-    pub fn mk_anonymous_var(&self, sort: Sort) -> Term {
+    pub fn mk_anonymous_var(&self, sort: Sort) -> Term<'_> {
         Term::from_raw(unsafe { mk_var(self.ptr_mut(), sort.inner, std::ptr::null()) })
     }
 
     // ── Datatype declarations ──────────────────────────────────────
 
     /// Create a datatype constructor declaration with the given name.
-    pub fn mk_dt_cons_decl(&self, name: &str) -> DatatypeConstructorDecl {
+    pub fn mk_dt_cons_decl(&self, name: &str) -> DatatypeConstructorDecl<'_> {
         let c = CString::new(name).unwrap();
         DatatypeConstructorDecl::from_raw(unsafe { mk_dt_cons_decl(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a datatype declaration. Set `is_codt` to `true` for codatatypes.
-    pub fn mk_dt_decl(&self, name: &str, is_codt: bool) -> DatatypeDecl {
+    pub fn mk_dt_decl(&self, name: &str, is_codt: bool) -> DatatypeDecl<'_> {
         let c = CString::new(name).unwrap();
         DatatypeDecl::from_raw(unsafe { mk_dt_decl(self.ptr_mut(), c.as_ptr(), is_codt) })
     }
@@ -472,7 +475,7 @@ impl TermManager {
         name: &str,
         params: &[Sort],
         is_codt: bool,
-    ) -> DatatypeDecl {
+    ) -> DatatypeDecl<'_> {
         let c = CString::new(name).unwrap();
         let raw: Vec<cvc5_sys::Sort> = params.iter().map(|s| s.inner).collect();
         DatatypeDecl::from_raw(unsafe {
@@ -481,12 +484,12 @@ impl TermManager {
     }
 
     /// Create a string constant from a null-terminated `wchar_t` array.
-    pub fn mk_string_from_wchar(&self, s: &[wchar_t]) -> Term {
+    pub fn mk_string_from_wchar(&self, s: &[wchar_t]) -> Term<'_> {
         Term::from_raw(unsafe { mk_string_from_wchar(self.ptr_mut(), s.as_ptr()) })
     }
 
     /// Create a string constant from a null-terminated `char32_t` array.
-    pub fn mk_string_from_char32(&self, s: &[char32_t]) -> Term {
+    pub fn mk_string_from_char32(&self, s: &[char32_t]) -> Term<'_> {
         Term::from_raw(unsafe { mk_string_from_char32(self.ptr_mut(), s.as_ptr()) })
     }
 


### PR DESCRIPTION
Closes #31 

adds lifetime parameters ('tm) via PhantomData to all types returned by TermManager, ensuring they cannot outlive it at compile time.