### PR TITLE
build: Default to dynamic link

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --all-features
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ rust-version = "1.85.1"
 
 [features]
 parser = ["cvc5-sys/parser"]
+vendored = ["cvc5-sys/vendored"]
 
 [dependencies]
 cvc5-sys = { path = "cvc5-sys", version = "=0.4.0" }
 
 [package.metadata.docs.rs]
-features = ["parser"]
+features = ["parser", "vendored"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ rust-version = "1.85.1"
 
 [features]
 parser = ["cvc5-sys/parser"]
-vendored = ["cvc5-sys/vendored"]
+static = ["cvc5-sys/static"]
 
 [dependencies]
 cvc5-sys = { path = "cvc5-sys", version = "=0.4.0" }
 
 [package.metadata.docs.rs]
-features = ["parser", "vendored"]
+features = ["parser", "static"]

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ so that `cvc5-sys` can build against it:
 CVC5_DIR = { value = "cvc5", relative = true }
 ```
 
+Enable the `vendored` feature to statically-link against cvc5.
+
 ### Linking Against a Prebuilt cvc5
 
 If you already have cvc5 built, you can skip the automatic build by setting `CVC5_LIB_DIR` to the
-directory containing the static libraries (`libcvc5.a`, etc.):
+directory containing the static (if `vendored`) or dynamic libraries (`libcvc5.a`, etc.):
 
 ```bash
 CVC5_LIB_DIR=/path/to/cvc5/build/lib cargo build

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ algebraic datatypes, and more.
 
 ## Prerequisites
 
-- Rust 2024 edition (1.85+)
-- cvc5 1.3.1 source (included as a git submodule in `cvc5-sys/cvc5`; built automatically by `cvc5-sys` if needed)
+- cvc5 1.3.1 (included as a git submodule in `cvc5-sys/cvc5`; built automatically by `cvc5-sys` if needed)
+
+If building from source using the `static` feature, install
+
 - A C/C++ compiler, CMake ≥ 3.16, and libclang (for bindgen)
 - Git (for automatic source download when installed from crates.io)
 
@@ -55,12 +57,12 @@ so that `cvc5-sys` can build against it:
 CVC5_DIR = { value = "cvc5", relative = true }
 ```
 
-Enable the `vendored` feature to statically-link against cvc5.
+Enable the `static` feature to statically-link against cvc5.
 
 ### Linking Against a Prebuilt cvc5
 
 If you already have cvc5 built, you can skip the automatic build by setting `CVC5_LIB_DIR` to the
-directory containing the static (if `vendored`) or dynamic libraries (`libcvc5.a`, etc.):
+directory containing the static (if `static`) or dynamic libraries (`libcvc5.a`, etc.):
 
 ```bash
 CVC5_LIB_DIR=/path/to/cvc5/build/lib cargo build

--- a/cvc5-sys/Cargo.toml
+++ b/cvc5-sys/Cargo.toml
@@ -16,7 +16,7 @@ version = "1.3.1"
 
 [features]
 parser = []
-vendored = []
+static = []
 
 [build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -24,4 +24,4 @@ toml = "0.8"
 convert_case = "^0.11"
 
 [package.metadata.docs.rs]
-features = ["parser", "vendored"]
+features = ["parser", "static"]

--- a/cvc5-sys/Cargo.toml
+++ b/cvc5-sys/Cargo.toml
@@ -16,6 +16,7 @@ version = "1.3.1"
 
 [features]
 parser = []
+vendored = []
 
 [build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
@@ -23,4 +24,4 @@ toml = "0.8"
 convert_case = "^0.11"
 
 [package.metadata.docs.rs]
-features = ["parser"]
+features = ["parser", "vendored"]

--- a/cvc5-sys/README.md
+++ b/cvc5-sys/README.md
@@ -7,9 +7,10 @@ For a safe, idiomatic Rust API, see the higher-level [`cvc5-rs`](https://github.
 
 ## Prerequisites
 
-This crate wraps cvc5 1.3.1 (the expected version is declared in `Cargo.toml` under
-`[package.metadata.cvc5]`). If cvc5 has not been compiled yet, the build script runs
-`configure.sh --static --auto-download` and `make` automatically. You need:
+When the `static` feature is enabled, this crate wraps cvc5 1.3.1 (the expected
+version is declared in `Cargo.toml` under `[package.metadata.cvc5]`). If cvc5
+has not been compiled yet, the build script runs `configure.sh --static
+--auto-download` and `make` automatically. You need:
 
 - A C/C++ compiler (GCC or Clang)
 - CMake ≥ 3.16
@@ -48,7 +49,7 @@ CVC5_DIR = { value = "cvc5", relative = true }
 ## Linking Against a Prebuilt cvc5
 
 If you already have cvc5 built, you can skip the automatic build by setting `CVC5_LIB_DIR` to the
-directory containing the static libraries (`libcvc5.a`, etc.):
+directory containing the static (if `static`) or dynamic libraries (`libcvc5.a`, etc.):
 
 ```bash
 CVC5_LIB_DIR=/path/to/cvc5/build/lib cargo build

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -309,8 +309,14 @@ fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
         .map(|n| n.get().to_string())
         .unwrap_or_else(|_| "4".to_string());
 
+    let mut targets: Vec<&str> = vec!["cvc5"];
+    if cfg!(feature = "parser") {
+        targets.push("cvc5parser");
+    }
+
     let status = Command::new("make")
         .arg(format!("-j{jobs}"))
+        .args(targets)
         .current_dir(cvc5_dir.join("build"))
         .status()
         .expect("Failed to run make");

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -4,6 +4,13 @@ use std::{env, path::PathBuf, process::Command};
 use bindgen::callbacks::{ItemKind, ParseCallbacks};
 use convert_case::{Case, Casing as _};
 
+fn link_with(name: &str) {
+    #[cfg(feature = "vendored")]
+    println!("cargo:rustc-link-lib=static={name}");
+    #[cfg(not(feature = "vendored"))]
+    println!("cargo:rustc-link-lib=dylib={name}");
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CVC5_LIB_DIR");
@@ -37,6 +44,7 @@ fn main() {
     let cvc5_dir = find_cvc5_dir();
     let expected = read_expected_cvc5_version();
     check_cvc5_version(&cvc5_dir, &expected);
+    #[cfg(feature = "vendored")]
     ensure_cvc5_built(&cvc5_dir);
 
     let include_dir = cvc5_dir.join("include");
@@ -48,7 +56,7 @@ fn main() {
         "cargo:rustc-link-search=native={}",
         build_dir.join("src").display()
     );
-    println!("cargo:rustc-link-lib=static=cvc5");
+    link_with("cvc5");
 
     // Link parser library
     if cfg!(feature = "parser") {
@@ -56,7 +64,7 @@ fn main() {
             "cargo:rustc-link-search=native={}",
             build_dir.join("src/parser").display()
         );
-        println!("cargo:rustc-link-lib=static=cvc5parser");
+        link_with("cvc5parser");
     }
 
     // Link dependencies
@@ -66,7 +74,7 @@ fn main() {
         for lib in &["cadical", "picpoly", "picpolyxx", "gmp"] {
             let path = deps_lib.join(format!("lib{lib}.a"));
             if path.exists() {
-                println!("cargo:rustc-link-lib=static={lib}");
+                link_with(lib);
             }
         }
     }
@@ -258,6 +266,7 @@ fn check_cvc5_version(cvc5_dir: &Path, expected: &str) {
 }
 
 #[cfg(unix)]
+#[cfg(feature = "vendored")]
 fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
     if cvc5_dir.join("build/src/libcvc5.a").exists() {
         return;
@@ -372,16 +381,16 @@ fn link_prebuilt(lib_dir: &Path) {
 
     // Link
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
-    println!("cargo:rustc-link-lib=static=cvc5");
+    link_with("cvc5");
 
     if cfg!(feature = "parser") {
-        println!("cargo:rustc-link-lib=static=cvc5parser");
+        link_with("cvc5parser");
     }
 
     // Link bundled dependencies if present
     for lib in &["cadical", "picpoly", "picpolyxx", "gmp"] {
         if lib_dir.join(format!("lib{lib}.a")).exists() {
-            println!("cargo:rustc-link-lib=static={lib}");
+            link_with(lib);
         }
     }
 

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -5,9 +5,9 @@ use bindgen::callbacks::{ItemKind, ParseCallbacks};
 use convert_case::{Case, Casing as _};
 
 fn link_with(name: &str) {
-    #[cfg(feature = "vendored")]
+    #[cfg(feature = "static")]
     println!("cargo:rustc-link-lib=static={name}");
-    #[cfg(not(feature = "vendored"))]
+    #[cfg(not(feature = "static"))]
     println!("cargo:rustc-link-lib=dylib={name}");
 }
 
@@ -44,7 +44,7 @@ fn main() {
     let cvc5_dir = find_cvc5_dir();
     let expected = read_expected_cvc5_version();
     check_cvc5_version(&cvc5_dir, &expected);
-    #[cfg(feature = "vendored")]
+    #[cfg(feature = "static")]
     ensure_cvc5_built(&cvc5_dir);
 
     let include_dir = cvc5_dir.join("include");
@@ -266,7 +266,7 @@ fn check_cvc5_version(cvc5_dir: &Path, expected: &str) {
 }
 
 #[cfg(unix)]
-#[cfg(feature = "vendored")]
+#[cfg(feature = "static")]
 fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
     if cvc5_dir.join("build/src/libcvc5.a").exists() {
         return;

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -388,7 +388,7 @@ fn link_prebuilt(lib_dir: &Path) {
     }
 
     // Link bundled dependencies if present
-    for lib in &["cadical", "picpoly", "picpolyxx", "gmp"] {
+    for lib in &["cadical", "gmp"] {
         if lib_dir.join(format!("lib{lib}.a")).exists() {
             link_with(lib);
         }

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -3,6 +3,10 @@ use std::{env, path::PathBuf, process::Command};
 
 use bindgen::callbacks::{ItemKind, ParseCallbacks};
 use convert_case::{Case, Casing as _};
+#[cfg(feature = "static")]
+const LIB_EXTENSION: &str = "a";
+#[cfg(not(feature = "static"))]
+const LIB_EXTENSION: &str = "so";
 
 fn link_with(name: &str) {
     #[cfg(feature = "static")]
@@ -71,8 +75,15 @@ fn main() {
     let deps_lib = build_dir.join("deps/lib");
     if deps_lib.exists() {
         println!("cargo:rustc-link-search=native={}", deps_lib.display());
-        for lib in &["cadical", "picpoly", "picpolyxx", "gmp"] {
-            let path = deps_lib.join(format!("lib{lib}.a"));
+        for lib in &["cadical", "gmp"] {
+            let path = deps_lib.join(format!("lib{lib}.{LIB_EXTENSION}"));
+            if path.exists() {
+                link_with(lib);
+            }
+        }
+        #[cfg(feature = "static")]
+        for lib in &["picpoly", "picpolyxx"] {
+            let path = deps_lib.join(format!("lib{lib}.{LIB_EXTENSION}"));
             if path.exists() {
                 link_with(lib);
             }
@@ -307,6 +318,7 @@ fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
 }
 
 #[cfg(not(unix))]
+#[cfg(feature = "static")]
 fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
     assert!(
         cvc5_dir.join("build/src/libcvc5.a").exists(),
@@ -389,7 +401,14 @@ fn link_prebuilt(lib_dir: &Path) {
 
     // Link bundled dependencies if present
     for lib in &["cadical", "gmp"] {
-        if lib_dir.join(format!("lib{lib}.a")).exists() {
+        if lib_dir.join(format!("lib{lib}.{LIB_EXTENSION}")).exists() {
+            link_with(lib);
+        }
+    }
+    #[cfg(feature = "static")]
+    for lib in &["picpoly", "picpolyxx"] {
+        let path = lib_dir.join(format!("lib{lib}.{LIB_EXTENSION}"));
+        if path.exists() {
             link_with(lib);
         }
     }


### PR DESCRIPTION
Resolves #40 

Adds a `static` feature flag to both sys and rs crates. When this option is turned on, we use static linking.