### PR TITLE
chore: Cleanup `strong_count`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -59,9 +59,6 @@ impl Drop for RawSymbolManager {
 ///
 /// A `SymbolManager` can be shared with an [`InputParser`] so that parsed
 /// commands update the same symbol table.
-///
-/// Uses interior mutability (`Rc<RefCell<…>>`) so the manager can be
-/// cheaply cloned and shared while still allowing mutation through `&self`.
 #[derive(Clone)]
 pub struct SymbolManager {
     inner: Rc<RawSymbolManager>,

--- a/src/term_manager.rs
+++ b/src/term_manager.rs
@@ -19,12 +19,6 @@ impl Drop for RawTermManager {
 }
 
 /// Manages creation of sorts, terms, and operators.
-///
-/// Uses interior mutability (`Rc<RefCell<…>>`) so the manager can be
-/// cheaply cloned and shared while still allowing mutation through `&self`.
-///
-/// All objects created by a `TermManager` carry a lifetime tied to the
-/// manager, ensuring they cannot outlive it.
 #[derive(Clone)]
 pub struct TermManager {
     inner: Rc<RawTermManager>,


### PR DESCRIPTION
Resolves #43

- [x] Remove calls to `strong_count` and replace it with an inner unexposed raw type. Makes it easier to switch to `Arc`
- [x] Remove `ptr_mut` in `TermManager`. It makes no sense to have mutable reference to a primitive (pointer) and then proceed to not mutate it.
- [x] Remove `RefCell` and use just an `Rc`. Since we don't mutate the primitive pointer inside `TermManager`, we don't need to track its access information, thus removing overhead.

This has no impact on the API.