### PR TITLE
refactor: Strip `Cvc5` prefix from sys bindings

### DIFF
--- a/cvc5-sys/README.md
+++ b/cvc5-sys/README.md
@@ -80,24 +80,24 @@ All symbols mirror the C API directly. Every call is `unsafe`.
 use cvc5_sys::*;
 
 unsafe {
-    let tm = cvc5_term_manager_new();
-    let slv = cvc5_new(tm);
+    let tm = term_manager_new();
+    let slv = new(tm);
 
-    cvc5_set_logic(slv, c"QF_LIA".as_ptr());
-    cvc5_set_option(slv, c"produce-models".as_ptr(), c"true".as_ptr());
+    set_logic(slv, c"QF_LIA".as_ptr());
+    set_option(slv, c"produce-models".as_ptr(), c"true".as_ptr());
 
-    let int_sort = cvc5_get_integer_sort(tm);
-    let x = cvc5_mk_const(tm, int_sort, c"x".as_ptr());
-    let zero = cvc5_mk_integer_int64(tm, 0);
+    let int_sort = get_integer_sort(tm);
+    let x = mk_const(tm, int_sort, c"x".as_ptr());
+    let zero = mk_integer_int64(tm, 0);
 
-    let gt = cvc5_mk_term(tm, Cvc5Kind::CVC5_KIND_GT, 2, [x, zero].as_ptr());
-    cvc5_assert_formula(slv, gt);
+    let gt = mk_term(tm, Kind::Gt, 2, [x, zero].as_ptr());
+    assert_formula(slv, gt);
 
-    let result = cvc5_check_sat(slv);
-    assert!(cvc5_result_is_sat(result));
+    let result = check_sat(slv);
+    assert!(result_is_sat(result));
 
-    cvc5_delete(slv);
-    cvc5_term_manager_delete(tm);
+    delete(slv);
+    term_manager_delete(tm);
 }
 ```
 

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::{env, path::PathBuf, process::Command};
 
-use bindgen::callbacks::ParseCallbacks;
+use bindgen::callbacks::{ItemKind, ParseCallbacks};
 use convert_case::{Case, Casing as _};
 
 fn main() {
@@ -82,6 +82,22 @@ fn main() {
 #[derive(Debug)]
 struct RenamingCallback;
 impl ParseCallbacks for RenamingCallback {
+    fn item_name(&self, item_info: bindgen::callbacks::ItemInfo<'_>) -> Option<String> {
+        let prefix = match item_info.kind {
+            ItemKind::Type => "Cvc5",
+            ItemKind::Var => "CVC5_",
+            ItemKind::Function => "cvc5_",
+            _ => {
+                return None;
+            }
+        };
+        let name = item_info.name.strip_prefix(prefix)?;
+        if name.is_empty() {
+            // Special case for the solver
+            return Some("Solver".to_string());
+        };
+        Some(name.to_string())
+    }
     fn enum_variant_name(
         &self,
         enum_name: Option<&str>,
@@ -173,6 +189,7 @@ fn generate_bindings(include_dir: &Path, build_include_dir: &Path) {
                 .clang_arg(format!("-I{}", include_dir.display()))
                 .clang_arg(format!("-I{}", build_include_dir.display()))
                 .clang_arg("-DCVC5_STATIC_DEFINE")
+                .parse_callbacks(Box::new(RenamingCallback))
                 .allowlist_function("cvc5_parser_.*")
                 .allowlist_function("cvc5_cmd_.*")
                 .allowlist_function("cvc5_symbol_manager_.*")

--- a/cvc5-sys/prebuilt/bindings.rs
+++ b/cvc5-sys/prebuilt/bindings.rs
@@ -6,7 +6,7 @@ pub type __uint_least32_t = __uint32_t;
 #[repr(i32)]
 #[doc = " The kind of a cvc5 Term.\n\n \\internal\n\n Note that the API type `cvc5::Kind` roughly corresponds to\n `cvc5::internal::Kind`, but is a different type. It hides internal kinds\n that should not be exported to the API, and maps all kinds that we want to\n export to its corresponding internal kinds. The underlying type of\n `cvc5::Kind` must be signed (to enable range checks for validity). The size\n of this type depends on the size of `cvc5::internal::Kind`\n (`NodeValue::NBITS_KIND`, currently 10 bits, see expr/node_value.h)."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5Kind {
+pub enum Kind {
     InternalKind = -2,
     UndefinedKind = -1,
     NullTerm = 0,
@@ -305,16 +305,18 @@ pub enum Cvc5Kind {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5Kind.\n @param kind The kind.\n @return The string representation."]
-    pub fn cvc5_kind_to_string(kind: Cvc5Kind) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_kind_to_string"]
+    pub fn kind_to_string(kind: Kind) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Hash function for Cvc5Kinds.\n @param kind The kind.\n @return The hash value."]
-    pub fn cvc5_kind_hash(kind: Cvc5Kind) -> usize;
+    #[link_name = "\u{1}cvc5_kind_hash"]
+    pub fn kind_hash(kind: Kind) -> usize;
 }
 #[repr(i32)]
 #[doc = " The kind of a cvc5 Sort.\n\n \\internal\n\n Note that the API type `cvc5::SortKind` roughly corresponds to\n `cvc5::internal::Kind`, but is a different type. It hides internal kinds\n that should not be exported to the API, and maps all kinds that we want to\n export to its corresponding internal kinds. The underlying type of\n `cvc5::Kind` must be signed (to enable range checks for validity). The size\n of this type depends on the size of `cvc5::internal::Kind`\n (`NodeValue::NBITS_KIND`, currently 10 bits, see expr/node_value.h)."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5SortKind {
+pub enum SortKind {
     InternalSortKind = -2,
     UndefinedSortKind = -1,
     NullSort = 0,
@@ -341,16 +343,18 @@ pub enum Cvc5SortKind {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5SortKind.\n @param kind The sort kind.\n @return The string representation."]
-    pub fn cvc5_sort_kind_to_string(kind: Cvc5SortKind) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_sort_kind_to_string"]
+    pub fn sort_kind_to_string(kind: SortKind) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Hash function for Cvc5SortKinds.\n @param kind The kind.\n @return The hash value."]
-    pub fn cvc5_sort_kind_hash(kind: Cvc5SortKind) -> usize;
+    #[link_name = "\u{1}cvc5_sort_kind_hash"]
+    pub fn sort_kind_hash(kind: SortKind) -> usize;
 }
 #[repr(u32)]
 #[doc = " \\internal\n This documentation is target for the online documentation that can\n be found at https://cvc5.github.io/docs/latest/proofs/proof_rules.html\n \\endinternal\n\n \\verbatim embed:rst:leading-asterisk\n An enumeration for proof rules. This enumeration is analogous to Kind for\n Node objects.\n\n All proof rules are given as inference rules, presented in the following\n form:\n\n .. math::\n\n   \\texttt{RULENAME}:\n   \\inferruleSC{\\varphi_1 \\dots \\varphi_n \\mid t_1 \\dots t_m}{\\psi}{if $C$}\n\n where we call :math:`\\varphi_i` its premises or children, :math:`t_i` its\n arguments, :math:`\\psi` its conclusion, and :math:`C` its side condition.\n Alternatively, we can write the application of a proof rule as\n ``(RULENAME F1 ... Fn :args t1 ... tm)``, omitting the conclusion\n (since it can be uniquely determined from premises and arguments).\n Note that premises are sometimes given as proofs, i.e., application of\n proof rules, instead of formulas. This abuses the notation to see proof\n rule applications and their conclusions interchangeably.\n\n Conceptually, the following proof rules form a calculus whose target\n user is the Node-level theory solvers. This means that the rules below\n are designed to reason about, among other things, common operations on Node\n objects like Rewriter::rewrite or Node::substitute. It is intended to be\n translated or printed in other formats.\n\n The following ProofRule values include core rules and those categorized by\n theory, including the theory of equality.\n\n The \"core rules\" include two distinguished rules which have special status:\n (1) :cpp:enumerator:`ASSUME <cvc5::ProofRule::ASSUME>`, which represents an\n open leaf in a proof; and\n (2) :cpp:enumerator:`SCOPE <cvc5::ProofRule::SCOPE>`, which encloses a scope\n (a subproof) with a set of scoped assumptions.\n The core rules additionally correspond to generic operations that are done\n internally on nodes, e.g., calling `Rewriter::rewrite()`.\n\n Rules with prefix ``MACRO_`` are those that can be defined in terms of other\n rules. These exist for convenience and can be replaced by their definition\n in post-processing.\n \\endverbatim"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5ProofRule {
+pub enum ProofRule {
     Assume = 0,
     Scope = 1,
     Subs = 2,
@@ -513,7 +517,7 @@ pub enum Cvc5ProofRule {
 #[repr(u32)]
 #[doc = " \\verbatim embed:rst:leading-asterisk\n This enumeration represents the rewrite rules used in a rewrite proof. Some\n of the rules are internal ad-hoc rewrites, while others are rewrites\n specified by the RARE DSL. This enumeration is used as the first argument to\n the :cpp:enumerator:`DSL_REWRITE <cvc5::ProofRule::DSL_REWRITE>` proof rule\n and the :cpp:enumerator:`THEORY_REWRITE <cvc5::ProofRule::THEORY_REWRITE>`\n proof rule.\n \\endverbatim"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5ProofRewriteRule {
+pub enum ProofRewriteRule {
     None = 0,
     DistinctElim = 1,
     DistinctCardConflict = 2,
@@ -1038,26 +1042,28 @@ pub enum Cvc5ProofRewriteRule {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5ProofRule.\n @param rule The proof rule.\n @return The string representation."]
-    pub fn cvc5_proof_rule_to_string(rule: Cvc5ProofRule) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_proof_rule_to_string"]
+    pub fn proof_rule_to_string(rule: ProofRule) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Hash function for Cvc5ProofRule.\n @param rule The proof rule.\n @return The hash value."]
-    pub fn cvc5_proof_rule_hash(rule: Cvc5ProofRule) -> usize;
+    #[link_name = "\u{1}cvc5_proof_rule_hash"]
+    pub fn proof_rule_hash(rule: ProofRule) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5ProofRewriteRule.\n @param rule The proof rewrite rule.\n @return The string representation."]
-    pub fn cvc5_proof_rewrite_rule_to_string(
-        rule: Cvc5ProofRewriteRule,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_proof_rewrite_rule_to_string"]
+    pub fn proof_rewrite_rule_to_string(rule: ProofRewriteRule) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Hash function for Cvc5ProofRewriteRule.\n @param rule The proof rewrite rule.\n @return The hash value."]
-    pub fn cvc5_proof_rewrite_rule_hash(rule: Cvc5ProofRewriteRule) -> usize;
+    #[link_name = "\u{1}cvc5_proof_rewrite_rule_hash"]
+    pub fn proof_rewrite_rule_hash(rule: ProofRewriteRule) -> usize;
 }
 #[repr(u32)]
 #[doc = " The kind of a cvc5 skolem. A skolem is a (family of) internal functions or\n constants that are introduced by cvc5. These symbols are treated as\n uninterpreted internally. We track their definition for the purposes of\n formal bookkeeping for the user of features like proofs, lemma exporting,\n simplification and so on.\n\n A skolem has an identifier and a set of \"skolem indices\". The skolem\n indices are *not* children of the skolem function, but rather should\n be seen as the way of distinguishing skolems from the same family.\n\n For example, the family of \"array diff\" skolems ``ARRAY_DEQ_DIFF`` witness\n the disequality between two arrays, which are its skolem indices.\n\n Say that skolem k witnesses the disequality between two arrays A and B\n of type ``(Array Int Int)``. Then, k is a term whose skolem identifier is\n ``ARRAY_DEQ_DIFF``, skolem indices are A and B, and whose type is ``Int``.\n\n Note the type of k is not ``(-> (Array Int Int) (Array Int Int) Int)``.\n Intuitively, this is due to the fact that cvc5 does not reason about array\n diff skolem as a function symbol. Furthermore, the array diff skolem that\n witnesses the disequality of arrays C and D is a separate skolem function k2\n from this family, also of type ``Int``, where internally k2 has no relation\n to k apart from having the same skolem identifier.\n\n In contrast, cvc5 reasons about division-by-zero using a single skolem\n function whose identifier is ``DIV_BY_ZERO``. This means its skolem indices\n are empty and the skolem has a functional type ``(-> Real Real)``.\n\n \\internal\n"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5SkolemId {
+pub enum SkolemId {
     Internal = 0,
     Purify = 1,
     GroundTerm = 2,
@@ -1123,16 +1129,18 @@ pub enum Cvc5SkolemId {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5SkolemId.\n @param id The skolem id.\n @return The string representation."]
-    pub fn cvc5_skolem_id_to_string(id: Cvc5SkolemId) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_skolem_id_to_string"]
+    pub fn skolem_id_to_string(id: SkolemId) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Hash function for Cvc5SkolemId.\n @param id The skolem id.\n @return The hash value."]
-    pub fn cvc5_skolem_id_hash(id: Cvc5SkolemId) -> usize;
+    #[link_name = "\u{1}cvc5_skolem_id_hash"]
+    pub fn skolem_id_hash(id: SkolemId) -> usize;
 }
 #[repr(u32)]
 #[doc = " The different reasons for returning an \"unknown\" result."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5UnknownExplanation {
+pub enum UnknownExplanation {
     RequiresFullCheck = 0,
     Incomplete = 1,
     Timeout = 2,
@@ -1147,14 +1155,13 @@ pub enum Cvc5UnknownExplanation {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5UnknownExplanation.\n @param exp The unknown explanation.\n @return The string representation."]
-    pub fn cvc5_unknown_explanation_to_string(
-        exp: Cvc5UnknownExplanation,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_unknown_explanation_to_string"]
+    pub fn unknown_explanation_to_string(exp: UnknownExplanation) -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " Rounding modes for floating-point numbers.\n\n For many floating-point operations, infinitely precise results may not be\n representable with the number of available bits. Thus, the results are\n rounded in a certain way to one of the representable floating-point numbers.\n\n \\verbatim embed:rst:leading-asterisk\n These rounding modes directly follow the SMT-LIB theory for floating-point\n arithmetic, which in turn is based on IEEE Standard 754 :cite:`IEEE754`.\n The rounding modes are specified in Sections 4.3.1 and 4.3.2 of the IEEE\n Standard 754.\n \\endverbatim"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5RoundingMode {
+pub enum RoundingMode {
     RoundNearestTiesToEven = 0,
     RoundTowardPositive = 1,
     RoundTowardNegative = 2,
@@ -1164,26 +1171,28 @@ pub enum Cvc5RoundingMode {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5RoundingMode.\n @param rm The rounding mode.\n @return The string representation."]
-    pub fn cvc5_rm_to_string(rm: Cvc5RoundingMode) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_rm_to_string"]
+    pub fn rm_to_string(rm: RoundingMode) -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " Mode for blocking models.\n\n Specifies how models are blocked in Solver::blockModel and\n Solver::blockModelValues."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5BlockModelsMode {
+pub enum BlockModelsMode {
     Literals = 0,
     Values = 1,
     Last = 2,
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5BlockModelsMode.\n @param mode The mode.\n @return The string representation."]
-    pub fn cvc5_modes_block_models_mode_to_string(
-        mode: Cvc5BlockModelsMode,
+    #[link_name = "\u{1}cvc5_modes_block_models_mode_to_string"]
+    pub fn modes_block_models_mode_to_string(
+        mode: BlockModelsMode,
     ) -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " Types of learned literals.\n\n Specifies categories of literals learned for the method\n Solver::getLearnedLiterals.\n\n Note that a literal may conceptually belong to multiple categories. We\n classify literals based on the first criteria in this list that they meet."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5LearnedLitType {
+pub enum LearnedLitType {
     PreprocessSolved = 0,
     Preprocess = 1,
     Input = 2,
@@ -1195,14 +1204,14 @@ pub enum Cvc5LearnedLitType {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5LearnedLitType.\n @param type The learned literal type.\n @return The string representation."]
-    pub fn cvc5_modes_learned_lit_type_to_string(
-        type_: Cvc5LearnedLitType,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_modes_learned_lit_type_to_string"]
+    pub fn modes_learned_lit_type_to_string(type_: LearnedLitType)
+    -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " Components to include in a proof."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5ProofComponent {
+pub enum ProofComponent {
     RawPreprocess = 0,
     Preprocess = 1,
     Sat = 2,
@@ -1212,14 +1221,13 @@ pub enum Cvc5ProofComponent {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5ProofComponent.\n @param pc The proof component.\n @return The string representation."]
-    pub fn cvc5_modes_proof_component_to_string(
-        pc: Cvc5ProofComponent,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_modes_proof_component_to_string"]
+    pub fn modes_proof_component_to_string(pc: ProofComponent) -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " Proof format used for proof printing."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5ProofFormat {
+pub enum ProofFormat {
     None = 0,
     Dot = 1,
     Lfsc = 2,
@@ -1230,14 +1238,13 @@ pub enum Cvc5ProofFormat {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5ProofFormat.\n @param format The proof format.\n @return The string representation."]
-    pub fn cvc5_modes_proof_format_to_string(
-        format: Cvc5ProofFormat,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_modes_proof_format_to_string"]
+    pub fn modes_proof_format_to_string(format: ProofFormat) -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " Find synthesis targets, used as an argument to Solver::findSynth. These\n specify various kinds of terms that can be found by this method."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5FindSynthTarget {
+pub enum FindSynthTarget {
     Enum = 0,
     Rewrite = 1,
     RewriteUnsound = 2,
@@ -1247,14 +1254,15 @@ pub enum Cvc5FindSynthTarget {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5FindSynthTarget.\n @param target The synthesis find target.\n @return The string representation."]
-    pub fn cvc5_modes_find_synth_target_to_string(
-        target: Cvc5FindSynthTarget,
+    #[link_name = "\u{1}cvc5_modes_find_synth_target_to_string"]
+    pub fn modes_find_synth_target_to_string(
+        target: FindSynthTarget,
     ) -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " Option category enumeration.\n Specifies the category of an option for user interface purposes."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5OptionCategory {
+pub enum OptionCategory {
     Regular = 0,
     Expert = 1,
     Common = 2,
@@ -1263,14 +1271,13 @@ pub enum Cvc5OptionCategory {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5OptionCategory.\n @param cat The option category.\n @return The string representation."]
-    pub fn cvc5_modes_option_category_to_string(
-        cat: Cvc5OptionCategory,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_modes_option_category_to_string"]
+    pub fn modes_option_category_to_string(cat: OptionCategory) -> *const ::std::os::raw::c_char;
 }
 #[repr(u32)]
 #[doc = " The different reasons for returning an \"unknown\" result."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5InputLanguage {
+pub enum InputLanguage {
     SmtLib26 = 0,
     Sygus21 = 1,
     Unknown = 2,
@@ -1278,9 +1285,8 @@ pub enum Cvc5InputLanguage {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a Cvc5InputLanguage.\n @param lang The input language.\n @return The string representation."]
-    pub fn cvc5_modes_input_language_to_string(
-        lang: Cvc5InputLanguage,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_modes_input_language_to_string"]
+    pub fn modes_input_language_to_string(lang: InputLanguage) -> *const ::std::os::raw::c_char;
 }
 pub type char32_t = __uint_least32_t;
 #[repr(C)]
@@ -1289,85 +1295,85 @@ pub struct cvc5_result_t {
     _unused: [u8; 0],
 }
 #[doc = " Encapsulation of a three-valued solver result, with explanations."]
-pub type Cvc5Result = *mut cvc5_result_t;
+pub type Result = *mut cvc5_result_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_synth_result_t {
     _unused: [u8; 0],
 }
 #[doc = " Encapsulation of a solver synth result.\n\n This is the return value of the API functions:\n   - cvc5_check_synth()\n   - cvc5_check_synth_next()\n\n which we call \"synthesis queries\".  This class indicates whether the\n synthesis query has a solution, has no solution, or is unknown."]
-pub type Cvc5SynthResult = *mut cvc5_synth_result_t;
+pub type SynthResult = *mut cvc5_synth_result_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_sort_t {
     _unused: [u8; 0],
 }
 #[doc = " The sort of a cvc5 term."]
-pub type Cvc5Sort = *mut cvc5_sort_t;
+pub type Sort = *mut cvc5_sort_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_term_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 term."]
-pub type Cvc5Term = *mut cvc5_term_t;
+pub type Term = *mut cvc5_term_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_op_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 operator.\n\n An operator is a term that represents certain operators, instantiated\n with its required parameters, e.g., a Term of kind\n #CVC5_KIND_BITVECTOR_EXTRACT."]
-pub type Cvc5Op = *mut cvc5_op_t;
+pub type Op = *mut cvc5_op_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_dt_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 datatype."]
-pub type Cvc5Datatype = *mut cvc5_dt_t;
+pub type Datatype = *mut cvc5_dt_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_dt_sel_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 datatype selector."]
-pub type Cvc5DatatypeSelector = *mut cvc5_dt_sel_t;
+pub type DatatypeSelector = *mut cvc5_dt_sel_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_dt_cons_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 datatype constructor."]
-pub type Cvc5DatatypeConstructor = *mut cvc5_dt_cons_t;
+pub type DatatypeConstructor = *mut cvc5_dt_cons_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_dt_cons_decl_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 datatype constructor declaration. A datatype constructor declaration\n is a specification used for creating a datatype constructor."]
-pub type Cvc5DatatypeConstructorDecl = *mut cvc5_dt_cons_decl_t;
+pub type DatatypeConstructorDecl = *mut cvc5_dt_cons_decl_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_dt_decl_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 datatype declaration. A datatype declaration is not itself a datatype\n (see Datatype), but a specification for creating a datatype sort.\n\n The interface for a datatype declaration coincides with the syntax for the\n SMT-LIB 2.6 command `declare-datatype`, or a single datatype within the\n `declare-datatypes` command.\n\n Datatype sorts can be constructed from a Cvc5DatatypeDecl using:\n   - cvc5_mk_datatype_sort()\n   - cvc5_mk_datatype_sorts()"]
-pub type Cvc5DatatypeDecl = *mut cvc5_dt_decl_t;
+pub type DatatypeDecl = *mut cvc5_dt_decl_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_grammar_t {
     _unused: [u8; 0],
 }
 #[doc = " A Sygus Grammar. This can be used to define a context-free grammar\n of terms. Its interface coincides with the definition of grammars\n (``GrammarDef``) in the SyGuS IF 2.1 standard."]
-pub type Cvc5Grammar = *mut cvc5_grammar_t;
+pub type Grammar = *mut cvc5_grammar_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5 {
+pub struct Solver {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5TermManager {
+pub struct TermManager {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -1376,1482 +1382,1719 @@ pub struct cvc5_proof_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 proof."]
-pub type Cvc5Proof = *mut cvc5_proof_t;
+pub type Proof = *mut cvc5_proof_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_stat_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 statistic."]
-pub type Cvc5Stat = *mut cvc5_stat_t;
+pub type Stat = *mut cvc5_stat_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct cvc5_stats_t {
     _unused: [u8; 0],
 }
 #[doc = " A cvc5 statistics instance."]
-pub type Cvc5Statistics = *mut cvc5_stats_t;
+pub type Statistics = *mut cvc5_stats_t;
 unsafe extern "C" {
     #[doc = " Make copy of result, increases reference counter of `result`.\n\n @param result The result to copy.\n @return The same result with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_result_copy(result: Cvc5Result) -> Cvc5Result;
+    #[link_name = "\u{1}cvc5_result_copy"]
+    pub fn result_copy(result: Result) -> Result;
 }
 unsafe extern "C" {
     #[doc = " Release copy of result, decrements reference counter of `result`.\n\n @param result The result to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a copy\n       that is owned by the callee of the function and thus, can be released."]
-    pub fn cvc5_result_release(result: Cvc5Result);
+    #[link_name = "\u{1}cvc5_result_release"]
+    pub fn result_release(result: Result);
 }
 unsafe extern "C" {
     #[doc = " Determine if a given result is empty (a nullary result) and not an actual\n result returned from a `cvc5_check_sat()` (and friends) query.\n @param result The result.\n @return True if the given result is a nullary result."]
-    pub fn cvc5_result_is_null(result: Cvc5Result) -> bool;
+    #[link_name = "\u{1}cvc5_result_is_null"]
+    pub fn result_is_null(result: Result) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given result is from a satisfiable `cvc5_check_sat()` or\n cvc5_check_sat_ssuming() query.\n @param result The result.\n @return True if result is from a satisfiable query."]
-    pub fn cvc5_result_is_sat(result: Cvc5Result) -> bool;
+    #[link_name = "\u{1}cvc5_result_is_sat"]
+    pub fn result_is_sat(result: Result) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given result is from an unsatisfiable `cvc5_check_sat()` or\n cvc5_check_sat_assuming() query.\n @param result The result.\n @return True if result is from an unsatisfiable query."]
-    pub fn cvc5_result_is_unsat(result: Cvc5Result) -> bool;
+    #[link_name = "\u{1}cvc5_result_is_unsat"]
+    pub fn result_is_unsat(result: Result) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given result is from a `cvc5_check_sat()` or\n cvc5_check_sat_assuming() query and cvc5 was not able to determine\n (un)satisfiability.\n @param result The result.\n @return True if result is from a query where cvc5 was not able to determine\n         (un)satisfiability."]
-    pub fn cvc5_result_is_unknown(result: Cvc5Result) -> bool;
+    #[link_name = "\u{1}cvc5_result_is_unknown"]
+    pub fn result_is_unknown(result: Result) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine equality of two results.\n @param a The first result to compare to for equality.\n @param b The second result to compare to for equality.\n @return True if the results are equal."]
-    pub fn cvc5_result_is_equal(a: Cvc5Result, b: Cvc5Result) -> bool;
+    #[link_name = "\u{1}cvc5_result_is_equal"]
+    pub fn result_is_equal(a: Result, b: Result) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Operator overloading for disequality of two results.\n @param a The first result to compare to for disequality.\n @param b The second result to compare to for disequality.\n @return True if the results are disequal."]
-    pub fn cvc5_result_is_disequal(a: Cvc5Result, b: Cvc5Result) -> bool;
+    #[link_name = "\u{1}cvc5_result_is_disequal"]
+    pub fn result_is_disequal(a: Result, b: Result) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the explanation for an unknown result.\n @param result The result.\n @return An explanation for an unknown query result."]
-    pub fn cvc5_result_get_unknown_explanation(result: Cvc5Result) -> Cvc5UnknownExplanation;
+    #[link_name = "\u{1}cvc5_result_get_unknown_explanation"]
+    pub fn result_get_unknown_explanation(result: Result) -> UnknownExplanation;
 }
 unsafe extern "C" {
     #[doc = " Get the string representation of a given result.\n @param result The result.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_result_to_string(result: Cvc5Result) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_result_to_string"]
+    pub fn result_to_string(result: Result) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a result.\n @param result The result.\n @return The hash value of the result."]
-    pub fn cvc5_result_hash(result: Cvc5Result) -> usize;
+    #[link_name = "\u{1}cvc5_result_hash"]
+    pub fn result_hash(result: Result) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given synthesis result is empty (a nullary result) and not an\n actual result returned from a synthesis query.\n @param result The result.\n @return True if the given result is a nullary result."]
-    pub fn cvc5_synth_result_is_null(result: Cvc5SynthResult) -> bool;
+    #[link_name = "\u{1}cvc5_synth_result_is_null"]
+    pub fn synth_result_is_null(result: SynthResult) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if the given result is from a synthesis query that has a solution.\n @param result The result.\n @return True if the synthesis query has a solution."]
-    pub fn cvc5_synth_result_has_solution(result: Cvc5SynthResult) -> bool;
+    #[link_name = "\u{1}cvc5_synth_result_has_solution"]
+    pub fn synth_result_has_solution(result: SynthResult) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if the given result is from a synthesis query that has no solution.\n @param result The result.\n @return True if the synthesis query has no solution. In this case, it\n         was determined that there was no solution."]
-    pub fn cvc5_synth_result_has_no_solution(result: Cvc5SynthResult) -> bool;
+    #[link_name = "\u{1}cvc5_synth_result_has_no_solution"]
+    pub fn synth_result_has_no_solution(result: SynthResult) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if the given result is from a synthesis query where its result\n could not be determined.\n @param result The result.\n @return True if the result of the synthesis query could not be determined."]
-    pub fn cvc5_synth_result_is_unknown(result: Cvc5SynthResult) -> bool;
+    #[link_name = "\u{1}cvc5_synth_result_is_unknown"]
+    pub fn synth_result_is_unknown(result: SynthResult) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine equality of two synthesis results.\n @param a The first synthesis result to compare to for equality.\n @param b The second synthesis result to compare to for equality.\n @return True if the synthesis results are equal."]
-    pub fn cvc5_synth_result_is_equal(a: Cvc5SynthResult, b: Cvc5SynthResult) -> bool;
+    #[link_name = "\u{1}cvc5_synth_result_is_equal"]
+    pub fn synth_result_is_equal(a: SynthResult, b: SynthResult) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Operator overloading for disequality of two synthesis results.\n @param a The first synthesis result to compare to for disequality.\n @param b The second synthesis result to compare to for disequality.\n @return True if the synthesis results are disequal."]
-    pub fn cvc5_synth_result_is_disequal(a: Cvc5SynthResult, b: Cvc5SynthResult) -> bool;
+    #[link_name = "\u{1}cvc5_synth_result_is_disequal"]
+    pub fn synth_result_is_disequal(a: SynthResult, b: SynthResult) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the string representation of a given result.\n @param result The result.\n @return A string representation of the given synthesis result.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_synth_result_to_string(result: Cvc5SynthResult) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_synth_result_to_string"]
+    pub fn synth_result_to_string(result: SynthResult) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a synthesis result.\n @param result The synthesis result.\n @return The hash value of the synthesis result."]
-    pub fn cvc5_synth_result_hash(result: Cvc5SynthResult) -> usize;
+    #[link_name = "\u{1}cvc5_synth_result_hash"]
+    pub fn synth_result_hash(result: SynthResult) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of synthesis result, increases reference counter of `result`.\n\n @param result The synthesis  result to copy.\n @return The same result with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_synth_result_copy(result: Cvc5SynthResult) -> Cvc5SynthResult;
+    #[link_name = "\u{1}cvc5_synth_result_copy"]
+    pub fn synth_result_copy(result: SynthResult) -> SynthResult;
 }
 unsafe extern "C" {
     #[doc = " Release copy of synthesis result, decrements reference counter of `result`.\n\n @param result The result to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a copy\n       that is owned by the callee of the function and thus, can be released."]
-    pub fn cvc5_synth_result_release(result: Cvc5SynthResult);
+    #[link_name = "\u{1}cvc5_synth_result_release"]
+    pub fn synth_result_release(result: SynthResult);
 }
 unsafe extern "C" {
     #[doc = " Make copy of sort, increases reference counter of `sort`.\n\n @param sort The sort to copy.\n @return The same sort with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_sort_copy(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_copy"]
+    pub fn sort_copy(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Release copy of sort, decrements reference counter of `sort`.\n\n @param sort The sort to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a\n       Cvc5Sort returns a copy that is owned by the callee of the function\n       and thus, can be released."]
-    pub fn cvc5_sort_release(sort: Cvc5Sort);
+    #[link_name = "\u{1}cvc5_sort_release"]
+    pub fn sort_release(sort: Sort);
 }
 unsafe extern "C" {
     #[doc = " Compare two sorts for structural equality.\n @param a The first sort.\n @param b The second sort.\n @return True if the sorts are equal."]
-    pub fn cvc5_sort_is_equal(a: Cvc5Sort, b: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_equal"]
+    pub fn sort_is_equal(a: Sort, b: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compare two sorts for structural disequality.\n @param a The first sort.\n @param b The second sort.\n @return True if the sorts are not equal."]
-    pub fn cvc5_sort_is_disequal(a: Cvc5Sort, b: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_disequal"]
+    pub fn sort_is_disequal(a: Sort, b: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compare two sorts for ordering.\n @param a The first sort.\n @param b The second sort.\n @return An integer value indicating the ordering: 0 if both sorts are equal,\n         `-1` if `a < b`, and `1` if `b > a`."]
-    pub fn cvc5_sort_compare(a: Cvc5Sort, b: Cvc5Sort) -> i64;
+    #[link_name = "\u{1}cvc5_sort_compare"]
+    pub fn sort_compare(a: Sort, b: Sort) -> i64;
 }
 unsafe extern "C" {
     #[doc = " Get the kind of the given sort.\n @param sort The sort.\n @return The kind of the sort.\n\n @warning This function is experimental and may change in future versions."]
-    pub fn cvc5_sort_get_kind(sort: Cvc5Sort) -> Cvc5SortKind;
+    #[link_name = "\u{1}cvc5_sort_get_kind"]
+    pub fn sort_get_kind(sort: Sort) -> SortKind;
 }
 unsafe extern "C" {
     #[doc = " Determine if the given sort has a symbol (a name).\n\n For example, uninterpreted sorts and uninterpreted sort constructors have\n symbols.\n\n @param sort The sort.\n @return True if the sort has a symbol."]
-    pub fn cvc5_sort_has_symbol(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_has_symbol"]
+    pub fn sort_has_symbol(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the symbol of this Sort.\n\n @note Asserts cvc5_sort_has_symbol().\n\n The symbol of this sort is the string that was\n provided when constructing it via\n cvc5_mk_uninterpreted_sort(),\n cvc5_mk_unresolved_sort(), or\n cvc5_mk_uninterpreted_sort_constructor_sort().\n\n @param sort The sort.\n @return The raw symbol of the sort.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_sort_get_symbol(sort: Cvc5Sort) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_sort_get_symbol"]
+    pub fn sort_get_symbol(sort: Sort) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is the Boolean sort (SMT-LIB: `Bool`).\n @param sort The sort.\n @return True if given sort is the Boolean sort."]
-    pub fn cvc5_sort_is_boolean(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_boolean"]
+    pub fn sort_is_boolean(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is the integer sort (SMT-LIB: `Int`).\n @param sort The sort.\n @return True if given sort is the integer sort."]
-    pub fn cvc5_sort_is_integer(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_integer"]
+    pub fn sort_is_integer(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is the real sort (SMT-LIB: `Real`).\n @param sort The sort.\n @return True if given sort is the real sort."]
-    pub fn cvc5_sort_is_real(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_real"]
+    pub fn sort_is_real(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is the string sort (SMT-LIB: `String`).\n @param sort The sort.\n @return True if given sort is the string sort."]
-    pub fn cvc5_sort_is_string(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_string"]
+    pub fn sort_is_string(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is the regular expression sort (SMT-LIB: `RegLan`).\n @param sort The sort.\n @return True if given sort is the regular expression sort."]
-    pub fn cvc5_sort_is_regexp(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_regexp"]
+    pub fn sort_is_regexp(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is the rounding mode sort\n (SMT-LIB: `Cvc5RoundingMode`).\n @param sort The sort.\n @return True if given sort is the rounding mode sort."]
-    pub fn cvc5_sort_is_rm(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_rm"]
+    pub fn sort_is_rm(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a bit-vector sort (SMT-LIB: `(_ BitVec i)`).\n @param sort The sort.\n @return True if given sort is a bit-vector sort."]
-    pub fn cvc5_sort_is_bv(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_bv"]
+    pub fn sort_is_bv(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a floatingpoint sort\n (SMT-LIB: `(_ FloatingPoint eb sb)`).\n @param sort The sort.\n @return True if given sort is a floating-point sort."]
-    pub fn cvc5_sort_is_fp(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_fp"]
+    pub fn sort_is_fp(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a datatype sort.\n @param sort The sort.\n @return True if given sort is a datatype sort."]
-    pub fn cvc5_sort_is_dt(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_dt"]
+    pub fn sort_is_dt(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a datatype constructor sort.\n @param sort The sort.\n @return True if given sort is a datatype constructor sort."]
-    pub fn cvc5_sort_is_dt_constructor(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_dt_constructor"]
+    pub fn sort_is_dt_constructor(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a datatype selector sort.\n @param sort The sort.\n @return True if given sort is a datatype selector sort."]
-    pub fn cvc5_sort_is_dt_selector(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_dt_selector"]
+    pub fn sort_is_dt_selector(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a datatype tester sort.\n @param sort The sort.\n @return True if given sort is a datatype tester sort."]
-    pub fn cvc5_sort_is_dt_tester(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_dt_tester"]
+    pub fn sort_is_dt_tester(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a datatype updater sort.\n @param sort The sort.\n @return True if given sort is a datatype updater sort."]
-    pub fn cvc5_sort_is_dt_updater(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_dt_updater"]
+    pub fn sort_is_dt_updater(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a function sort.\n @param sort The sort.\n @return True if given sort is a function sort."]
-    pub fn cvc5_sort_is_fun(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_fun"]
+    pub fn sort_is_fun(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a predicate sort.\n\n A predicate sort is a function sort that maps to the Boolean sort. All\n predicate sorts are also function sorts.\n\n @param sort The sort.\n @return True if given sort is a predicate sort."]
-    pub fn cvc5_sort_is_predicate(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_predicate"]
+    pub fn sort_is_predicate(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a tuple sort.\n @param sort The sort.\n @return True if given sort is a tuple sort."]
-    pub fn cvc5_sort_is_tuple(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_tuple"]
+    pub fn sort_is_tuple(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a nullable sort.\n @param sort The sort.\n @return True if given sort is a nullable sort."]
-    pub fn cvc5_sort_is_nullable(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_nullable"]
+    pub fn sort_is_nullable(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a record sort.\n @warning This function is experimental and may change in future versions.\n @param sort The sort.\n @return True if the sort is a record sort."]
-    pub fn cvc5_sort_is_record(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_record"]
+    pub fn sort_is_record(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is an array sort.\n @param sort The sort.\n @return True if the sort is an array sort."]
-    pub fn cvc5_sort_is_array(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_array"]
+    pub fn sort_is_array(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a finite field sort.\n @param sort The sort.\n @return True if the sort is a finite field sort."]
-    pub fn cvc5_sort_is_ff(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_ff"]
+    pub fn sort_is_ff(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a Set sort.\n @param sort The sort.\n @return True if the sort is a Set sort."]
-    pub fn cvc5_sort_is_set(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_set"]
+    pub fn sort_is_set(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a Bag sort.\n @param sort The sort.\n @return True if the sort is a Bag sort."]
-    pub fn cvc5_sort_is_bag(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_bag"]
+    pub fn sort_is_bag(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is a Sequence sort.\n @param sort The sort.\n @return True if the sort is a Sequence sort."]
-    pub fn cvc5_sort_is_sequence(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_sequence"]
+    pub fn sort_is_sequence(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is an abstract sort.\n @param sort The sort.\n @return True if the sort is a abstract sort.\n\n @warning This function is experimental and may change in future versions."]
-    pub fn cvc5_sort_is_abstract(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_abstract"]
+    pub fn sort_is_abstract(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is an uninterpreted sort.\n @param sort The sort.\n @return True if given sort is an uninterpreted sort."]
-    pub fn cvc5_sort_is_uninterpreted_sort(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_uninterpreted_sort"]
+    pub fn sort_is_uninterpreted_sort(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is an uninterpreted sort constructor.\n\n An uninterpreted sort constructor has arity > 0 and can be instantiated to\n construct uninterpreted sorts with given sort parameters.\n\n @param sort The sort.\n @return True if given sort is of sort constructor kind."]
-    pub fn cvc5_sort_is_uninterpreted_sort_constructor(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_uninterpreted_sort_constructor"]
+    pub fn sort_is_uninterpreted_sort_constructor(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if given sort is an instantiated (parametric datatype or\n uninterpreted sort constructor) sort.\n\n An instantiated sort is a sort that has been constructed from\n instantiating a sort with sort arguments (see cvc5_sort_instantiate().\n\n @param sort The sort.\n @return True if given sort is an instantiated sort."]
-    pub fn cvc5_sort_is_instantiated(sort: Cvc5Sort) -> bool;
+    #[link_name = "\u{1}cvc5_sort_is_instantiated"]
+    pub fn sort_is_instantiated(sort: Sort) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the associated uninterpreted sort constructor of an instantiated\n uninterpreted sort.\n\n @param sort The sort.\n @return The uninterpreted sort constructor sort."]
-    pub fn cvc5_sort_get_uninterpreted_sort_constructor(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_get_uninterpreted_sort_constructor"]
+    pub fn sort_get_uninterpreted_sort_constructor(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the underlying datatype of a datatype sort.\n @param sort The sort.\n @return The underlying datatype of a datatype sort."]
-    pub fn cvc5_sort_get_datatype(sort: Cvc5Sort) -> Cvc5Datatype;
+    #[link_name = "\u{1}cvc5_sort_get_datatype"]
+    pub fn sort_get_datatype(sort: Sort) -> Datatype;
 }
 unsafe extern "C" {
     #[doc = " Instantiate a parameterized datatype sort or uninterpreted sort\n constructor sort.\n\n Create sort parameters with cvc5_mk_param_sort().\n\n @param sort   The sort to instantiate.\n @param size   The number of sort parameters to instantiate with.\n @param params The list of sort parameters to instantiate with.\n @return The instantiated sort."]
-    pub fn cvc5_sort_instantiate(sort: Cvc5Sort, size: usize, params: *const Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_instantiate"]
+    pub fn sort_instantiate(sort: Sort, size: usize, params: *const Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the sorts used to instantiate the sort parameters of a given parametric\n sort (parametric datatype or uninterpreted sort constructor sort,\n see cvc5_sort_instantiate();\n\n @param sort The sort.\n @param size The size of the resulting array of sorts.\n @return The sorts used to instantiate the sort parameters of a\n         parametric sort"]
-    pub fn cvc5_sort_get_instantiated_parameters(
-        sort: Cvc5Sort,
-        size: *mut usize,
-    ) -> *const Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_get_instantiated_parameters"]
+    pub fn sort_get_instantiated_parameters(sort: Sort, size: *mut usize) -> *const Sort;
 }
 unsafe extern "C" {
     #[doc = " Substitution of Sorts.\n\n Note that this replacement is applied during a pre-order traversal and\n only once to the sort. It is not run until fix point.\n\n For example,\n `(Array A B).substitute({A, C}, {(Array C D), (Array A B)})` will\n return `(Array (Array C D) B)`.\n\n @warning This function is experimental and may change in future versions.\n\n @param sort The sort.\n @param s    The subsort to be substituted within the given sort.\n @param replacement The sort replacing the substituted subsort."]
-    pub fn cvc5_sort_substitute(sort: Cvc5Sort, s: Cvc5Sort, replacement: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_substitute"]
+    pub fn sort_substitute(sort: Sort, s: Sort, replacement: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Simultaneous substitution of Sorts.\n\n Note that this replacement is applied during a pre-order traversal and\n only once to the sort. It is not run until fix point. In the case that\n sorts contains duplicates, the replacement earliest in the vector takes\n priority.\n\n @warning This function is experimental and may change in future versions.\n\n @param sort The sort.\n @param sorts The subsorts to be substituted within the given sort.\n @param replacements The sort replacing the substituted subsorts.\n @param size The size of `sorts` and `replacements`."]
-    pub fn cvc5_sort_substitute_sorts(
-        sort: Cvc5Sort,
+    #[link_name = "\u{1}cvc5_sort_substitute_sorts"]
+    pub fn sort_substitute_sorts(
+        sort: Sort,
         size: usize,
-        sorts: *const Cvc5Sort,
-        replacements: *const Cvc5Sort,
-    ) -> Cvc5Sort;
+        sorts: *const Sort,
+        replacements: *const Sort,
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given sort.\n @param sort The sort.\n @return A string representation of the given sort.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_sort_to_string(sort: Cvc5Sort) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_sort_to_string"]
+    pub fn sort_to_string(sort: Sort) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a sort.\n @param sort The sort.\n @return The hash value of the sort."]
-    pub fn cvc5_sort_hash(sort: Cvc5Sort) -> usize;
+    #[link_name = "\u{1}cvc5_sort_hash"]
+    pub fn sort_hash(sort: Sort) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the arity of a datatype constructor sort.\n @param sort The sort.\n @return The arity of a datatype constructor sort."]
-    pub fn cvc5_sort_dt_constructor_get_arity(sort: Cvc5Sort) -> usize;
+    #[link_name = "\u{1}cvc5_sort_dt_constructor_get_arity"]
+    pub fn sort_dt_constructor_get_arity(sort: Sort) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the domain sorts of a datatype constructor sort.\n @param sort The sort.\n @param size The size of the resulting array of domain sorts.\n @return The domain sorts of a datatype constructor sort."]
-    pub fn cvc5_sort_dt_constructor_get_domain(sort: Cvc5Sort, size: *mut usize)
-    -> *const Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_dt_constructor_get_domain"]
+    pub fn sort_dt_constructor_get_domain(sort: Sort, size: *mut usize) -> *const Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the codomain sort of a datatype constructor sort.\n @param sort The sort.\n @return The codomain sort of a constructor sort."]
-    pub fn cvc5_sort_dt_constructor_get_codomain(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_dt_constructor_get_codomain"]
+    pub fn sort_dt_constructor_get_codomain(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the domain sort of a given datatype selector sort.\n @param sort The sort.\n @return The domain sort of a datatype selector sort."]
-    pub fn cvc5_sort_dt_selector_get_domain(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_dt_selector_get_domain"]
+    pub fn sort_dt_selector_get_domain(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the codomain sort of a given datatype selector sort.\n @param sort The sort.\n @return The codomain sort of a datatype selector sort."]
-    pub fn cvc5_sort_dt_selector_get_codomain(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_dt_selector_get_codomain"]
+    pub fn sort_dt_selector_get_codomain(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the domain sort of a given datatype tester sort.\n @param sort The sort.\n @return The domain sort of a datatype tester sort."]
-    pub fn cvc5_sort_dt_tester_get_domain(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_dt_tester_get_domain"]
+    pub fn sort_dt_tester_get_domain(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the codomain dort of a given datatype tester sort (the Boolean sort).\n @param sort The sort.\n @return The codomain sort of a datatype tester sort.\n\n @note We mainly need this for the symbol table, which doesn't have\n       access to the solver object."]
-    pub fn cvc5_sort_dt_tester_get_codomain(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_dt_tester_get_codomain"]
+    pub fn sort_dt_tester_get_codomain(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the aritye of a given function sort.\n @param sort The sort.\n @return The arity of a function sort."]
-    pub fn cvc5_sort_fun_get_arity(sort: Cvc5Sort) -> usize;
+    #[link_name = "\u{1}cvc5_sort_fun_get_arity"]
+    pub fn sort_fun_get_arity(sort: Sort) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the domain of a given function sort.\n @param sort The sort.\n @param size The size of the resulting array of domain sorts.\n @return The domain sorts of a function sort."]
-    pub fn cvc5_sort_fun_get_domain(sort: Cvc5Sort, size: *mut usize) -> *const Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_fun_get_domain"]
+    pub fn sort_fun_get_domain(sort: Sort, size: *mut usize) -> *const Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the codomain of a given function sort.\n @param sort The sort.\n @return The codomain sort of a function sort."]
-    pub fn cvc5_sort_fun_get_codomain(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_fun_get_codomain"]
+    pub fn sort_fun_get_codomain(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the index sort of a given array sort.\n @param sort The sort.\n @return The array index sort of an array sort."]
-    pub fn cvc5_sort_array_get_index_sort(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_array_get_index_sort"]
+    pub fn sort_array_get_index_sort(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the element sort of a given array sort.\n @param sort The sort.\n @return The array element sort of an array sort."]
-    pub fn cvc5_sort_array_get_element_sort(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_array_get_element_sort"]
+    pub fn sort_array_get_element_sort(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the element sort of a given set sort.\n @param sort The sort.\n @return The element sort of a set sort."]
-    pub fn cvc5_sort_set_get_element_sort(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_set_get_element_sort"]
+    pub fn sort_set_get_element_sort(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the element sort of a given bag sort.\n @param sort The sort.\n @return The element sort of a bag sort."]
-    pub fn cvc5_sort_bag_get_element_sort(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_bag_get_element_sort"]
+    pub fn sort_bag_get_element_sort(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the element sort of a sequence sort.\n @param sort The sort.\n @return The element sort of a sequence sort."]
-    pub fn cvc5_sort_sequence_get_element_sort(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_sequence_get_element_sort"]
+    pub fn sort_sequence_get_element_sort(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the kind of an abstract sort, which denotes the sort kinds that the\n abstract sort denotes.\n\n @param sort The sort.\n @return The kind of an abstract sort.\n\n @warning This function is experimental and may change in future versions."]
-    pub fn cvc5_sort_abstract_get_kind(sort: Cvc5Sort) -> Cvc5SortKind;
+    #[link_name = "\u{1}cvc5_sort_abstract_get_kind"]
+    pub fn sort_abstract_get_kind(sort: Sort) -> SortKind;
 }
 unsafe extern "C" {
     #[doc = " Get the arity of an uninterpreted sort constructor sort.\n @param sort The sort.\n @return The arity of an uninterpreted sort constructor sort."]
-    pub fn cvc5_sort_uninterpreted_sort_constructor_get_arity(sort: Cvc5Sort) -> usize;
+    #[link_name = "\u{1}cvc5_sort_uninterpreted_sort_constructor_get_arity"]
+    pub fn sort_uninterpreted_sort_constructor_get_arity(sort: Sort) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the size of a bit-vector sort.\n @param sort The sort.\n @return The bit-width of the bit-vector sort."]
-    pub fn cvc5_sort_bv_get_size(sort: Cvc5Sort) -> u32;
+    #[link_name = "\u{1}cvc5_sort_bv_get_size"]
+    pub fn sort_bv_get_size(sort: Sort) -> u32;
 }
 unsafe extern "C" {
     #[doc = " Get the size of a finite field sort.\n @param sort The sort.\n @return The size of the finite field sort.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_sort_ff_get_size(sort: Cvc5Sort) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_sort_ff_get_size"]
+    pub fn sort_ff_get_size(sort: Sort) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the exponent size of a floating-point sort.\n @param sort The sort.\n @return The bit-width of the exponent of the floating-point sort."]
-    pub fn cvc5_sort_fp_get_exp_size(sort: Cvc5Sort) -> u32;
+    #[link_name = "\u{1}cvc5_sort_fp_get_exp_size"]
+    pub fn sort_fp_get_exp_size(sort: Sort) -> u32;
 }
 unsafe extern "C" {
     #[doc = " Get the significand size of a floating-point sort.\n @param sort The sort.\n @return The width of the significand of the floating-point sort."]
-    pub fn cvc5_sort_fp_get_sig_size(sort: Cvc5Sort) -> u32;
+    #[link_name = "\u{1}cvc5_sort_fp_get_sig_size"]
+    pub fn sort_fp_get_sig_size(sort: Sort) -> u32;
 }
 unsafe extern "C" {
     #[doc = " Get the arity of a datatype sort, which is the number of type parameters\n if the datatype is parametric, or 0 otherwise.\n @param sort The sort.\n @return The arity of a datatype sort."]
-    pub fn cvc5_sort_dt_get_arity(sort: Cvc5Sort) -> usize;
+    #[link_name = "\u{1}cvc5_sort_dt_get_arity"]
+    pub fn sort_dt_get_arity(sort: Sort) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the length of a tuple sort.\n @param sort The sort.\n @return The length of a tuple sort."]
-    pub fn cvc5_sort_tuple_get_length(sort: Cvc5Sort) -> usize;
+    #[link_name = "\u{1}cvc5_sort_tuple_get_length"]
+    pub fn sort_tuple_get_length(sort: Sort) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the element sorts of a tuple sort.\n @param sort The sort.\n @param size The size of the resulting array of tuple element sorts.\n @return The element sorts of a tuple sort."]
-    pub fn cvc5_sort_tuple_get_element_sorts(sort: Cvc5Sort, size: *mut usize) -> *const Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_tuple_get_element_sorts"]
+    pub fn sort_tuple_get_element_sorts(sort: Sort, size: *mut usize) -> *const Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the element sort of a nullable sort.\n @param sort The sort.\n @return The element sort of a nullable sort."]
-    pub fn cvc5_sort_nullable_get_element_sort(sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sort_nullable_get_element_sort"]
+    pub fn sort_nullable_get_element_sort(sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Make copy of operator, increases reference counter of `op`.\n\n @param op The op to copy.\n @return The same op with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_op_copy(op: Cvc5Op) -> Cvc5Op;
+    #[link_name = "\u{1}cvc5_op_copy"]
+    pub fn op_copy(op: Op) -> Op;
 }
 unsafe extern "C" {
     #[doc = " Release copy of operator, decrements reference counter of `op`.\n\n @param op The op to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a\n       Cvc5Op returns a copy that is owned by the callee of the function\n       and thus, can be released."]
-    pub fn cvc5_op_release(op: Cvc5Op);
+    #[link_name = "\u{1}cvc5_op_release"]
+    pub fn op_release(op: Op);
 }
 unsafe extern "C" {
     #[doc = " Compare two operators for syntactic equality.\n\n @param a The first operator.\n @param b The second operator.\n @return True if both operators are syntactically identical."]
-    pub fn cvc5_op_is_equal(a: Cvc5Op, b: Cvc5Op) -> bool;
+    #[link_name = "\u{1}cvc5_op_is_equal"]
+    pub fn op_is_equal(a: Op, b: Op) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compare two operators for syntactic disequality.\n\n @param a The first operator.\n @param b The second operator.\n @return True if both operators are syntactically disequal."]
-    pub fn cvc5_op_is_disequal(a: Cvc5Op, b: Cvc5Op) -> bool;
+    #[link_name = "\u{1}cvc5_op_is_disequal"]
+    pub fn op_is_disequal(a: Op, b: Op) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the kind of a given operator.\n @param op The operator.\n @return The kind of the operator."]
-    pub fn cvc5_op_get_kind(op: Cvc5Op) -> Cvc5Kind;
+    #[link_name = "\u{1}cvc5_op_get_kind"]
+    pub fn op_get_kind(op: Op) -> Kind;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given operator is indexed.\n @param op The operator.\n @return True iff the operator is indexed."]
-    pub fn cvc5_op_is_indexed(op: Cvc5Op) -> bool;
+    #[link_name = "\u{1}cvc5_op_is_indexed"]
+    pub fn op_is_indexed(op: Op) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the number of indices of a given operator.\n @param op The operator.\n @return The number of indices of the operator."]
-    pub fn cvc5_op_get_num_indices(op: Cvc5Op) -> usize;
+    #[link_name = "\u{1}cvc5_op_get_num_indices"]
+    pub fn op_get_num_indices(op: Op) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the index at position `i` of an indexed operator.\n @param op The operator.\n @param i  The position of the index to return.\n @return The index at position i."]
-    pub fn cvc5_op_get_index(op: Cvc5Op, i: usize) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_op_get_index"]
+    pub fn op_get_index(op: Op, i: usize) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given operator.\n @param op The operator.\n @return A string representation of the operator.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_op_to_string(op: Cvc5Op) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_op_to_string"]
+    pub fn op_to_string(op: Op) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of an operator.\n @param op The operator.\n @return The hash value of the operator."]
-    pub fn cvc5_op_hash(op: Cvc5Op) -> usize;
+    #[link_name = "\u{1}cvc5_op_hash"]
+    pub fn op_hash(op: Op) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of term, increases reference counter of `term`.\n\n @param term The term to copy.\n @return The same term with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_term_copy(term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_copy"]
+    pub fn term_copy(term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Release copy of term, decrements reference counter of `term`.\n\n @param term The term to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a copy\n       that is owned by the callee of the function and thus, can be released."]
-    pub fn cvc5_term_release(term: Cvc5Term);
+    #[link_name = "\u{1}cvc5_term_release"]
+    pub fn term_release(term: Term);
 }
 unsafe extern "C" {
     #[doc = " Compare two terms for syntactic equality.\n @param a The first term.\n @param b The second term.\n @return True if both term are syntactically identical."]
-    pub fn cvc5_term_is_equal(a: Cvc5Term, b: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_equal"]
+    pub fn term_is_equal(a: Term, b: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compare two terms for syntactic disequality.\n @param a The first term.\n @param b The second term.\n @return True if both term are syntactically disequal."]
-    pub fn cvc5_term_is_disequal(a: Cvc5Term, b: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_disequal"]
+    pub fn term_is_disequal(a: Term, b: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compare two terms for ordering.\n @param a The first term.\n @param b The second term.\n @return An integer value indicating the ordering: 0 if both terms are equal,\n         `-1` if `a < b`, and `1` if `b > a`."]
-    pub fn cvc5_term_compare(a: Cvc5Term, b: Cvc5Term) -> i64;
+    #[link_name = "\u{1}cvc5_term_compare"]
+    pub fn term_compare(a: Term, b: Term) -> i64;
 }
 unsafe extern "C" {
     #[doc = " Get the number of children of a given term.\n @param term The term.\n @return The number of children of this term."]
-    pub fn cvc5_term_get_num_children(term: Cvc5Term) -> usize;
+    #[link_name = "\u{1}cvc5_term_get_num_children"]
+    pub fn term_get_num_children(term: Term) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the child term of a given term at a given index.\n @param term  The term.\n @param index The index of the child.\n @return The child term at the given index."]
-    pub fn cvc5_term_get_child(term: Cvc5Term, index: usize) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_child"]
+    pub fn term_get_child(term: Term, index: usize) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the id of a given term.\n @param term The term.\n @return The id of the term."]
-    pub fn cvc5_term_get_id(term: Cvc5Term) -> u64;
+    #[link_name = "\u{1}cvc5_term_get_id"]
+    pub fn term_get_id(term: Term) -> u64;
 }
 unsafe extern "C" {
     #[doc = " Get the kind of a given term.\n @param term The term.\n @return The kind of the term."]
-    pub fn cvc5_term_get_kind(term: Cvc5Term) -> Cvc5Kind;
+    #[link_name = "\u{1}cvc5_term_get_kind"]
+    pub fn term_get_kind(term: Term) -> Kind;
 }
 unsafe extern "C" {
     #[doc = " Get the sort of a given term.\n @param term The term.\n @return The sort of the term."]
-    pub fn cvc5_term_get_sort(term: Cvc5Term) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_term_get_sort"]
+    pub fn term_get_sort(term: Term) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Replace a given term `t` with term `replacement` in a given term.\n\n @param term        The term.\n @param t           The term to replace.\n @param replacement The term to replace it with.\n @return The result of replacing `term` with `replacement` in the term.\n\n @note This replacement is applied during a pre-order traversal and\n       only once (it is not run until fixed point)."]
-    pub fn cvc5_term_substitute_term(
-        term: Cvc5Term,
-        t: Cvc5Term,
-        replacement: Cvc5Term,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_substitute_term"]
+    pub fn term_substitute_term(term: Term, t: Term, replacement: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Simultaneously replace given terms `terms` with terms `replacements` in a\n given term.\n\n In the case that `terms` contains duplicates, the replacement earliest in\n the vector takes priority. For example, calling substitute on `f(x,y)`\n with `terms = { x, z }`, `replacements = { g(z), w }` results in the term\n `f(g(z),y)`.\n\n @note Requires that `terms` and `replacements` are of equal size (they are\n       interpreted as 1 : 1 mapping).\n\n @note This replacement is applied during a pre-order traversal and\n       only once (it is not run until fixed point).\n\n @param term        The term.\n @param size         The size of `terms` and `replacements`.\n @param terms        The terms to replace.\n @param replacements The replacement terms.\n @return The result of simultaneously replacing `terms` with `replacements`\n         in the given term."]
-    pub fn cvc5_term_substitute_terms(
-        term: Cvc5Term,
+    #[link_name = "\u{1}cvc5_term_substitute_terms"]
+    pub fn term_substitute_terms(
+        term: Term,
         size: usize,
-        terms: *const Cvc5Term,
-        replacements: *const Cvc5Term,
-    ) -> Cvc5Term;
+        terms: *const Term,
+        replacements: *const Term,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term has an operator.\n @param term The term.\n @return True iff the term has an operator."]
-    pub fn cvc5_term_has_op(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_has_op"]
+    pub fn term_has_op(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the operator of a term with an operator.\n\n @note Requires that the term has an operator (see cvc5_term_has_op()).\n\n @param term        The term.\n @return The Op used to create the term."]
-    pub fn cvc5_term_get_op(term: Cvc5Term) -> Cvc5Op;
+    #[link_name = "\u{1}cvc5_term_get_op"]
+    pub fn term_get_op(term: Term) -> Op;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term has a symbol (a name).\n\n For example, free constants and variables have symbols.\n\n @param term The term.\n @return True if the term has a symbol."]
-    pub fn cvc5_term_has_symbol(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_has_symbol"]
+    pub fn term_has_symbol(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the symbol of a given term with a symbol.\n\n @note Requires that the term has a symbol (see cvc5_term_has_symbol()).\n\n The symbol of the term is the string that was\n provided when constructing it via cvc5_mk_const() or cvc5_mk_var().\n\n @param term The term.\n @return The raw symbol of the term.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_term_get_symbol(term: Cvc5Term) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_term_get_symbol"]
+    pub fn term_get_symbol(term: Term) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given term.\n @param term The term.\n @return A string representation of the term.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_term_to_string(term: Cvc5Term) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_term_to_string"]
+    pub fn term_to_string(term: Term) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the sign of a given integer or real value.\n @note Requires that given term is an integer or real value.\n @param term The value term.\n @return 0 if the term is zero, -1 if the term is a negative real or\n         integer value, 1 if the term is a positive real or integer value."]
-    pub fn cvc5_term_get_real_or_integer_value_sign(term: Cvc5Term) -> i32;
+    #[link_name = "\u{1}cvc5_term_get_real_or_integer_value_sign"]
+    pub fn term_get_real_or_integer_value_sign(term: Term) -> i32;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is an int32 value.\n @note This will return true for integer constants and real constants that\n       have integer value.\n @param term The term.\n @return True if the term is an integer value that fits within int32_t."]
-    pub fn cvc5_term_is_int32_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_int32_value"]
+    pub fn term_is_int32_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the `int32_t` representation of a given integral value.\n @note Requires that the term is an int32 value (see\n       cvc5_term_is_int32_value()).\n @param term The term.\n @return The given term as `int32_t` value."]
-    pub fn cvc5_term_get_int32_value(term: Cvc5Term) -> i32;
+    #[link_name = "\u{1}cvc5_term_get_int32_value"]
+    pub fn term_get_int32_value(term: Term) -> i32;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is an uint32 value.\n @note This will return true for integer constants and real constants that\n       have integral value.\n @return True if the term is an integral value and fits within uint32_t."]
-    pub fn cvc5_term_is_uint32_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_uint32_value"]
+    pub fn term_is_uint32_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the `uint32_t` representation of a given integral value.\n @note Requires that the term is an uint32 value (see\n       cvc5_term_is_uint32_value()).\n @param term The term.\n @return The term as `uint32_t` value."]
-    pub fn cvc5_term_get_uint32_value(term: Cvc5Term) -> u32;
+    #[link_name = "\u{1}cvc5_term_get_uint32_value"]
+    pub fn term_get_uint32_value(term: Term) -> u32;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is an int64 value.\n @note This will return true for integer constants and real constants that\n       have integral value.\n @param term The term.\n @return True if the term is an integral value that fits within int64_t."]
-    pub fn cvc5_term_is_int64_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_int64_value"]
+    pub fn term_is_int64_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the `int64_t` representation of a given integral value.\n @note Requires that the term is an int64 value (see\n       cvc5_term_is_int64_value()).\n @param term The term.\n @return The term as `int64_t` value."]
-    pub fn cvc5_term_get_int64_value(term: Cvc5Term) -> i64;
+    #[link_name = "\u{1}cvc5_term_get_int64_value"]
+    pub fn term_get_int64_value(term: Term) -> i64;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is an uint64 value.\n @note This will return true for integer constants and real constants that\n       have integral value.\n @param term The term.\n @return True if the term is an integral value that fits within uint64_t."]
-    pub fn cvc5_term_is_uint64_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_uint64_value"]
+    pub fn term_is_uint64_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the `uint64_t` representation of a given integral value.\n @note Requires that the term is an uint64 value (see\n       cvc5_term_is_uint64_value()).\n @param term The term.\n @return The term as `uint64_t` value."]
-    pub fn cvc5_term_get_uint64_value(term: Cvc5Term) -> u64;
+    #[link_name = "\u{1}cvc5_term_get_uint64_value"]
+    pub fn term_get_uint64_value(term: Term) -> u64;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is an integral value.\n @param term The term.\n @return True if the term is an integer constant or a real constant that\n         has an integral value."]
-    pub fn cvc5_term_is_integer_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_integer_value"]
+    pub fn term_is_integer_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given integral value.\n @note Requires that the term is an integral value (see\n       cvc5_term_is_integer_value()).\n @param term The term.\n @return The integral term in (decimal) string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_term_get_integer_value(term: Cvc5Term) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_term_get_integer_value"]
+    pub fn term_get_integer_value(term: Term) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a string value.\n @param term The term.\n @return True if the term is a string value."]
-    pub fn cvc5_term_is_string_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_string_value"]
+    pub fn term_is_string_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the native string representation of a string value.\n @note Requires that the term is a string value (see\n       cvc5_term_is_string_value()).\n @note This is not to be confused with cvc5_term_to_string(), which returns\n       some string representation of the term, whatever data it may hold.\n @param term The term.\n @return The string term as a native string value.\n\n @warning This function is deprecated and replaced by\n          cvc5_term_get_u32string_value(). It will be removed in a future\n          release."]
-    pub fn cvc5_term_get_string_value(term: Cvc5Term) -> *const wchar_t;
+    #[link_name = "\u{1}cvc5_term_get_string_value"]
+    pub fn term_get_string_value(term: Term) -> *const wchar_t;
 }
 unsafe extern "C" {
     #[doc = " Get the native UTF-32 string representation of a string value.\n @note Requires that the term is a string value (see\n       cvc5_term_is_string_value()).\n @note This is not to be confused with cvc5_term_to_string(), which returns\n       some string representation of the term, whatever data it may hold.\n @param term The term.\n @return The string term as a native UTF-32 string value."]
-    pub fn cvc5_term_get_u32string_value(term: Cvc5Term) -> *const char32_t;
+    #[link_name = "\u{1}cvc5_term_get_u32string_value"]
+    pub fn term_get_u32string_value(term: Term) -> *const char32_t;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a rational value whose numerator fits into an\n int32 value and its denominator fits into a uint32 value.\n @param term The term.\n @return True if the term is a rational and its numerator and denominator\n         fit into 32 bit integer values."]
-    pub fn cvc5_term_is_real32_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_real32_value"]
+    pub fn term_is_real32_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the 32 bit integer representations of the numerator and denominator of\n a rational value.\n @note Requires that the term is a rational value and its numerator and\n       denominator fit into 32 bit integer values (see\n       cvc5_term_is_real32_value()).\n @param term The term.\n @param num  The resulting int32_t representation of the numerator.\n @param den  The resulting uint32_t representation of the denominator."]
-    pub fn cvc5_term_get_real32_value(term: Cvc5Term, num: *mut i32, den: *mut u32);
+    #[link_name = "\u{1}cvc5_term_get_real32_value"]
+    pub fn term_get_real32_value(term: Term, num: *mut i32, den: *mut u32);
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a rational value whose numerator fits into an\n int64 value and its denominator fits into a uint64 value.\n @param term The term.\n @return True if the term is a rational value whose numerator and\n         denominator fit within int64_t and uint64_t, respectively."]
-    pub fn cvc5_term_is_real64_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_real64_value"]
+    pub fn term_is_real64_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the 64 bit integer representations of the numerator and denominator of\n a rational value.\n @note Requires that the term is a rational value and its numerator and\n       denominator fit into 64 bit integer values (see\n       cvc5_term_is_real64_value()).\n @param term The term.\n @param num  The resulting int64_t representation of the numerator.\n @param den  The resulting uint64_t representation of the denominator."]
-    pub fn cvc5_term_get_real64_value(term: Cvc5Term, num: *mut i64, den: *mut u64);
+    #[link_name = "\u{1}cvc5_term_get_real64_value"]
+    pub fn term_get_real64_value(term: Term, num: *mut i64, den: *mut u64);
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a rational value.\n @note A term of kind PI is not considered to be a real value.\n @param term The term.\n @return True if the term is a rational value."]
-    pub fn cvc5_term_is_real_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_real_value"]
+    pub fn term_is_real_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given rational value.\n @note Requires that the term is a rational value (see\n       cvc5_term_is_real_value()).\n @param term The term.\n @return The representation of a rational value as a (rational) string.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_term_get_real_value(term: Cvc5Term) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_term_get_real_value"]
+    pub fn term_get_real_value(term: Term) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a constant array.\n @param term The term.\n @return True if the term is a constant array."]
-    pub fn cvc5_term_is_const_array(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_const_array"]
+    pub fn term_is_const_array(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine the base (element stored at all indices) of a constant array.\n @note Requires that the term is a constant array (see isConstArray()).\n @param term The term.\n @return The base term."]
-    pub fn cvc5_term_get_const_array_base(term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_const_array_base"]
+    pub fn term_get_const_array_base(term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a Boolean value.\n @param term The term.\n @return True if the term is a Boolean value."]
-    pub fn cvc5_term_is_boolean_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_boolean_value"]
+    pub fn term_is_boolean_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the value of a Boolean term as a native Boolean value.\n @note Asserts cvc5_term_is_boolean_value().\n @param term The term.\n @return The representation of a Boolean value as a native Boolean value."]
-    pub fn cvc5_term_get_boolean_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_get_boolean_value"]
+    pub fn term_get_boolean_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a bit-vector value.\n @param term The term.\n @return True if the term is a bit-vector value."]
-    pub fn cvc5_term_is_bv_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_bv_value"]
+    pub fn term_is_bv_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the string representation of a bit-vector value.\n @note Asserts cvc5_term_is_bv_value().\n @param term The term.\n @param base `2` for binary, `10` for decimal, and `16` for hexadecimal.\n @return The string representation of a bit-vector value.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_term_get_bv_value(term: Cvc5Term, base: u32) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_term_get_bv_value"]
+    pub fn term_get_bv_value(term: Term, base: u32) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a finite field value.\n @param term The term.\n @return True if the term is a finite field value."]
-    pub fn cvc5_term_is_ff_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_ff_value"]
+    pub fn term_is_ff_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the string representation of a finite field value (base 10).\n\n @note Asserts cvc5_term_is_ff_value().\n\n @note Uses the integer representative of smallest absolute value.\n\n @param term The term.\n @return The string representation of the integer representation of the\n         finite field value.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_term_get_ff_value(term: Cvc5Term) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_term_get_ff_value"]
+    pub fn term_get_ff_value(term: Term) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is an uninterpreted sort value.\n @param term The term.\n @return True if the term is an abstract value."]
-    pub fn cvc5_term_is_uninterpreted_sort_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_uninterpreted_sort_value"]
+    pub fn term_is_uninterpreted_sort_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of an uninterpreted sort value.\n @note Asserts cvc5_term_is_uninterpreted_sort_value().\n @param term The term.\n @return The representation of an uninterpreted sort value as a string.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_term_get_uninterpreted_sort_value(term: Cvc5Term) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_term_get_uninterpreted_sort_value"]
+    pub fn term_get_uninterpreted_sort_value(term: Term) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a tuple value.\n @param term The term.\n @return True if the term is a tuple value."]
-    pub fn cvc5_term_is_tuple_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_tuple_value"]
+    pub fn term_is_tuple_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a tuple value as an array of terms.\n @note Asserts cvc5_term_is_tuple_value().\n @param term The term.\n @param size The size of the resulting array.\n @return The representation of a tuple value as an array of terms."]
-    pub fn cvc5_term_get_tuple_value(term: Cvc5Term, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_tuple_value"]
+    pub fn term_get_tuple_value(term: Term, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a floating-point rounding mode value.\n @param term The term.\n @return True if the term is a rounding mode value."]
-    pub fn cvc5_term_is_rm_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_rm_value"]
+    pub fn term_is_rm_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the Cvc5RoundingMode value of a given rounding-mode value term.\n @note Asserts cvc5_term_is_rounding_mode_value().\n @param term The term.\n @return The floating-point rounding mode value of the term."]
-    pub fn cvc5_term_get_rm_value(term: Cvc5Term) -> Cvc5RoundingMode;
+    #[link_name = "\u{1}cvc5_term_get_rm_value"]
+    pub fn term_get_rm_value(term: Term) -> RoundingMode;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a floating-point positive zero value\n (+zero).\n @param term The term.\n @return True if the term is the floating-point value for positive zero."]
-    pub fn cvc5_term_is_fp_pos_zero(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_fp_pos_zero"]
+    pub fn term_is_fp_pos_zero(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a floating-point negative zero value (-zero).\n @param term The term.\n @return True if the term is the floating-point value for negative zero."]
-    pub fn cvc5_term_is_fp_neg_zero(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_fp_neg_zero"]
+    pub fn term_is_fp_neg_zero(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a floating-point positive infinity value (+oo).\n @param term The term.\n @return True if the term is the floating-point value for positive.\n         infinity."]
-    pub fn cvc5_term_is_fp_pos_inf(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_fp_pos_inf"]
+    pub fn term_is_fp_pos_inf(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a floating-point negative infinity value (-oo).\n @param term The term.\n @return True if the term is the floating-point value for negative.\n         infinity."]
-    pub fn cvc5_term_is_fp_neg_inf(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_fp_neg_inf"]
+    pub fn term_is_fp_neg_inf(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a floating-point NaN value.\n @param term The term.\n @return True if the term is the floating-point value for not a number."]
-    pub fn cvc5_term_is_fp_nan(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_fp_nan"]
+    pub fn term_is_fp_nan(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a floating-point value.\n @param term The term.\n @return True if the term is a floating-point value."]
-    pub fn cvc5_term_is_fp_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_fp_value"]
+    pub fn term_is_fp_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the representation of a floating-point value as its exponent width,\n significand width and a bit-vector value term.\n @note Asserts cvc5_term_is_fp_value().\n @param term The term.\n @param ew   The resulting exponent width.\n @param sw   The resulting significand width.\n @param val  The resulting bit-vector value term."]
-    pub fn cvc5_term_get_fp_value(term: Cvc5Term, ew: *mut u32, sw: *mut u32, val: *mut Cvc5Term);
+    #[link_name = "\u{1}cvc5_term_get_fp_value"]
+    pub fn term_get_fp_value(term: Term, ew: *mut u32, sw: *mut u32, val: *mut Term);
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a set value.\n\n A term is a set value if it is considered to be a (canonical) constant set\n value.  A canonical set value is one whose AST is:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (union (singleton c1) ... (union (singleton c_{n-1}) (singleton c_n))))\n \\endverbatim\n\n where @f$c_1 ... c_n@f$ are values ordered by id such that\n @f$c_1 > ... > c_n@f$.\n\n @note A universe set term (kind #CVC5_KIND_SET_UNIVERSE) is not considered\n       to be a set value.\n\n @param term The term.\n @return True if the term is a set value."]
-    pub fn cvc5_term_is_set_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_set_value"]
+    pub fn term_is_set_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a set value as an array of terms.\n @note Asserts cvc5_term_is_set_value().\n @param term The term.\n @param size The size of the resulting array.\n @return The representation of a set value as an array of terms."]
-    pub fn cvc5_term_get_set_value(term: Cvc5Term, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_set_value"]
+    pub fn term_get_set_value(term: Term, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a sequence value.\n\n A term is a sequence value if it has kind #CVC5_KIND_CONST_SEQUENCE. In\n contrast to values for the set sort (as described in isSetValue()), a\n sequence value is represented as a Term with no children.\n\n Semantically, a sequence value is a concatenation of unit sequences\n whose elements are themselves values. For example:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (seq.++ (seq.unit 0) (seq.unit 1))\n \\endverbatim\n\n The above term has two representations in Term. One is as the sequence\n concatenation term:\n\n \\rst\n .. code:: lisp\n\n     (SEQ_CONCAT (SEQ_UNIT 0) (SEQ_UNIT 1))\n \\endrst\n\n where 0 and 1 are the terms corresponding to the integer constants 0 and 1.\n\n Alternatively, the above term is represented as the constant sequence\n value:\n\n \\rst\n .. code:: lisp\n\n     CONST_SEQUENCE_{0,1}\n \\endrst\n\n where calling getSequenceValue() on the latter returns the vector `{0, 1}`.\n\n The former term is not a sequence value, but the latter term is.\n\n Constant sequences cannot be constructed directly via the API. They are\n returned in response to API calls such cvc5_get_value() and cvc5_simplify().\n\n @param term The term.\n @return True if the term is a sequence value."]
-    pub fn cvc5_term_is_sequence_value(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_sequence_value"]
+    pub fn term_is_sequence_value(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a sequence value as an array of terms.\n @note Asserts cvc5_term_is_sequence_value().\n @param term The term.\n @param size The size of the resulting array.\n @return The representation of a sequence value as a vector of terms."]
-    pub fn cvc5_term_get_sequence_value(term: Cvc5Term, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_sequence_value"]
+    pub fn term_get_sequence_value(term: Term, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a cardinality constraint.\n @param term The term.\n @return True if the term is a cardinality constraint."]
-    pub fn cvc5_term_is_cardinality_constraint(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_cardinality_constraint"]
+    pub fn term_is_cardinality_constraint(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a cardinality constraint as a pair of its sort and upper bound.\n @note Asserts cvc5_term_is_cardinality_constraint().\n @param term  The term.\n @param sort  The resulting sort.\n @param upper The resulting upper bound."]
-    pub fn cvc5_term_get_cardinality_constraint(
-        term: Cvc5Term,
-        sort: *mut Cvc5Sort,
-        upper: *mut u32,
-    );
+    #[link_name = "\u{1}cvc5_term_get_cardinality_constraint"]
+    pub fn term_get_cardinality_constraint(term: Term, sort: *mut Sort, upper: *mut u32);
 }
 unsafe extern "C" {
     #[doc = " Determine if a given term is a real algebraic number.\n @param term  The term.\n @return True if the term is a real algebraic number."]
-    pub fn cvc5_term_is_real_algebraic_number(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_real_algebraic_number"]
+    pub fn term_is_real_algebraic_number(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the defining polynomial for a real algebraic number term, expressed in\n terms of the given variable.\n @note Asserts cvc5_term_is_real_algebraic_number().\n @param term The real algebraic number term.\n @param v    The variable over which to express the polynomial.\n @return The defining polynomial."]
-    pub fn cvc5_term_get_real_algebraic_number_defining_polynomial(
-        term: Cvc5Term,
-        v: Cvc5Term,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_real_algebraic_number_defining_polynomial"]
+    pub fn term_get_real_algebraic_number_defining_polynomial(term: Term, v: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the lower bound for a real algebraic number value.\n @note Asserts cvc5_term_is_real_algebraic_number().\n @param term The real algebraic number value.\n @return The lower bound."]
-    pub fn cvc5_term_get_real_algebraic_number_lower_bound(term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_real_algebraic_number_lower_bound"]
+    pub fn term_get_real_algebraic_number_lower_bound(term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the upper bound for a real algebraic number value.\n @note Asserts cvc5_term_is_real_algebraic_number().\n @param term The real algebraic number value.\n @return The upper bound."]
-    pub fn cvc5_term_get_real_algebraic_number_upper_bound(term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_real_algebraic_number_upper_bound"]
+    pub fn term_get_real_algebraic_number_upper_bound(term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Is the given term a skolem?\n @warning This function is experimental and may change in future versions.\n @param term The skolem.\n @return True if the term is a skolem function."]
-    pub fn cvc5_term_is_skolem(term: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_term_is_skolem"]
+    pub fn term_is_skolem(term: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get skolem identifier of a term.\n @note Asserts isSkolem().\n @warning This function is experimental and may change in future versions.\n @param term The skolem.\n @return The skolem identifier of the term."]
-    pub fn cvc5_term_get_skolem_id(term: Cvc5Term) -> Cvc5SkolemId;
+    #[link_name = "\u{1}cvc5_term_get_skolem_id"]
+    pub fn term_get_skolem_id(term: Term) -> SkolemId;
 }
 unsafe extern "C" {
     #[doc = " Get the skolem indices of a term.\n @note Asserts isSkolem().\n @warning This function is experimental and may change in future versions.\n @param term The skolem.\n @param size The size of the resulting array.\n @return The skolem indices of the term. This is list of terms that the\n         skolem function is indexed by. For example, the array diff skolem\n         `Cvc5SkolemId::ARRAY_DEQ_DIFF` is indexed by two arrays."]
-    pub fn cvc5_term_get_skolem_indices(term: Cvc5Term, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_term_get_skolem_indices"]
+    pub fn term_get_skolem_indices(term: Term, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a term.\n @param term The term.\n @return The hash value of the term."]
-    pub fn cvc5_term_hash(term: Cvc5Term) -> usize;
+    #[link_name = "\u{1}cvc5_term_hash"]
+    pub fn term_hash(term: Term) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of datatype constructor declaration, increases reference counter\n of `decl`.\n\n @param decl The datatype constructor declaration to copy.\n @return The same datatype constructor declaration with its reference count\n         increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_dt_cons_decl_copy(decl: Cvc5DatatypeConstructorDecl)
-    -> Cvc5DatatypeConstructorDecl;
+    #[link_name = "\u{1}cvc5_dt_cons_decl_copy"]
+    pub fn dt_cons_decl_copy(decl: DatatypeConstructorDecl) -> DatatypeConstructorDecl;
 }
 unsafe extern "C" {
     #[doc = " Release copy of datatype constructor declaration, decrements reference\n counter of `decl`.\n\n @param decl The datatype constructor declaration to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a\n       Cvc5DatatypeConstructorDecl returns a copy that is owned by the callee\n       of the function and thus, can be released."]
-    pub fn cvc5_dt_cons_decl_release(decl: Cvc5DatatypeConstructorDecl);
+    #[link_name = "\u{1}cvc5_dt_cons_decl_release"]
+    pub fn dt_cons_decl_release(decl: DatatypeConstructorDecl);
 }
 unsafe extern "C" {
     #[doc = " Compare two datatype constructor declarations for structural equality.\n @param a The first datatype constructor declaration.\n @param b The second datatype constructor declaration.\n @return True if the datatype constructor declarations are equal."]
-    pub fn cvc5_dt_cons_decl_is_equal(
-        a: Cvc5DatatypeConstructorDecl,
-        b: Cvc5DatatypeConstructorDecl,
-    ) -> bool;
+    #[link_name = "\u{1}cvc5_dt_cons_decl_is_equal"]
+    pub fn dt_cons_decl_is_equal(a: DatatypeConstructorDecl, b: DatatypeConstructorDecl) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Add datatype selector declaration to a given constructor declaration.\n @param decl The datatype constructor declaration.\n @param name The name of the datatype selector declaration to add.\n @param sort The codomain sort of the datatype selector declaration to add."]
-    pub fn cvc5_dt_cons_decl_add_selector(
-        decl: Cvc5DatatypeConstructorDecl,
+    #[link_name = "\u{1}cvc5_dt_cons_decl_add_selector"]
+    pub fn dt_cons_decl_add_selector(
+        decl: DatatypeConstructorDecl,
         name: *const ::std::os::raw::c_char,
-        sort: Cvc5Sort,
+        sort: Sort,
     );
 }
 unsafe extern "C" {
     #[doc = " Add datatype selector declaration whose codomain type is the datatype\n itself to a given constructor declaration.\n @param decl The datatype constructor declaration.\n @param name The name of the datatype selector declaration to add."]
-    pub fn cvc5_dt_cons_decl_add_selector_self(
-        decl: Cvc5DatatypeConstructorDecl,
+    #[link_name = "\u{1}cvc5_dt_cons_decl_add_selector_self"]
+    pub fn dt_cons_decl_add_selector_self(
+        decl: DatatypeConstructorDecl,
         name: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Add datatype selector declaration whose codomain sort is an unresolved\n datatype with the given name to a given constructor declaration.\n @param decl       The datatype constructor declaration.\n @param name       The name of the datatype selector declaration to add.\n @param unres_name The name of the unresolved datatype. The codomain of the\n                   selector will be the resolved datatype with the given name."]
-    pub fn cvc5_dt_cons_decl_add_selector_unresolved(
-        decl: Cvc5DatatypeConstructorDecl,
+    #[link_name = "\u{1}cvc5_dt_cons_decl_add_selector_unresolved"]
+    pub fn dt_cons_decl_add_selector_unresolved(
+        decl: DatatypeConstructorDecl,
         name: *const ::std::os::raw::c_char,
         unres_name: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given constructor declaration.\n @param decl The datatype constructor declaration.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_cons_decl_to_string(
-        decl: Cvc5DatatypeConstructorDecl,
-    ) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_cons_decl_to_string"]
+    pub fn dt_cons_decl_to_string(decl: DatatypeConstructorDecl) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a datatype constructor declaration.\n @param decl The datatype constructor declaration.\n @return The hash value of the datatype constructor declaration."]
-    pub fn cvc5_dt_cons_decl_hash(decl: Cvc5DatatypeConstructorDecl) -> usize;
+    #[link_name = "\u{1}cvc5_dt_cons_decl_hash"]
+    pub fn dt_cons_decl_hash(decl: DatatypeConstructorDecl) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of datatype declaration, increases reference counter of `decl`.\n\n @param decl The datatype declaration to copy.\n @return The same datatype declarationwith its reference count increased by\n         one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_dt_decl_copy(decl: Cvc5DatatypeDecl) -> Cvc5DatatypeDecl;
+    #[link_name = "\u{1}cvc5_dt_decl_copy"]
+    pub fn dt_decl_copy(decl: DatatypeDecl) -> DatatypeDecl;
 }
 unsafe extern "C" {
     #[doc = " Release copy of datatype declaration, decrements reference counter of `decl`.\n\n @param decl The datatype declaration to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a\n       Cvc5DatatypeDecl returns a copy that is owned by the callee of the\n       function and thus, can be released."]
-    pub fn cvc5_dt_decl_release(decl: Cvc5DatatypeDecl);
+    #[link_name = "\u{1}cvc5_dt_decl_release"]
+    pub fn dt_decl_release(decl: DatatypeDecl);
 }
 unsafe extern "C" {
     #[doc = " Compare two datatype declarations for structural equality.\n @param a The first datatype declaration.\n @param b The second datatype declaration.\n @return True if the datatype declarations are equal."]
-    pub fn cvc5_dt_decl_is_equal(a: Cvc5DatatypeDecl, b: Cvc5DatatypeDecl) -> bool;
+    #[link_name = "\u{1}cvc5_dt_decl_is_equal"]
+    pub fn dt_decl_is_equal(a: DatatypeDecl, b: DatatypeDecl) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Add datatype constructor declaration.\n @param decl The datatype declaration.\n @param ctor The datatype constructor declaration to add."]
-    pub fn cvc5_dt_decl_add_constructor(decl: Cvc5DatatypeDecl, ctor: Cvc5DatatypeConstructorDecl);
+    #[link_name = "\u{1}cvc5_dt_decl_add_constructor"]
+    pub fn dt_decl_add_constructor(decl: DatatypeDecl, ctor: DatatypeConstructorDecl);
 }
 unsafe extern "C" {
     #[doc = " Get the number of constructors for a given Datatype declaration.\n @param decl The datatype declaration.\n @return The number of constructors."]
-    pub fn cvc5_dt_decl_get_num_constructors(decl: Cvc5DatatypeDecl) -> usize;
+    #[link_name = "\u{1}cvc5_dt_decl_get_num_constructors"]
+    pub fn dt_decl_get_num_constructors(decl: DatatypeDecl) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given Datatype declaration is parametric.\n @warning This function is experimental and may change in future versions.\n @param decl The datatype declaration.\n @return True if the datatype declaration is parametric."]
-    pub fn cvc5_dt_decl_is_parametric(decl: Cvc5DatatypeDecl) -> bool;
+    #[link_name = "\u{1}cvc5_dt_decl_is_parametric"]
+    pub fn dt_decl_is_parametric(decl: DatatypeDecl) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given datatype declaration is resolved (has already been\n used to declare a datatype).\n @param decl The datatype declaration.\n @return True if the datatype declaration is resolved."]
-    pub fn cvc5_dt_decl_is_resolved(decl: Cvc5DatatypeDecl) -> bool;
+    #[link_name = "\u{1}cvc5_dt_decl_is_resolved"]
+    pub fn dt_decl_is_resolved(decl: DatatypeDecl) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given datatype declaration.\n @param decl The datatype declaration.\n @return A string representation of the datatype declaration.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_decl_to_string(decl: Cvc5DatatypeDecl) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_decl_to_string"]
+    pub fn dt_decl_to_string(decl: DatatypeDecl) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the name of a given datatype declaration.\n @param decl The datatype declaration.\n @return The name of the datatype declaration.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_decl_get_name(decl: Cvc5DatatypeDecl) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_decl_get_name"]
+    pub fn dt_decl_get_name(decl: DatatypeDecl) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a datatype declaration.\n @param decl The datatype declaration.\n @return The hash value of the datatype declaration."]
-    pub fn cvc5_dt_decl_hash(decl: Cvc5DatatypeDecl) -> usize;
+    #[link_name = "\u{1}cvc5_dt_decl_hash"]
+    pub fn dt_decl_hash(decl: DatatypeDecl) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of datatype selector, increases reference counter of `sel`.\n\n @param sel The datatype selector to copy.\n @return The same datatype selector with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_dt_sel_copy(sel: Cvc5DatatypeSelector) -> Cvc5DatatypeSelector;
+    #[link_name = "\u{1}cvc5_dt_sel_copy"]
+    pub fn dt_sel_copy(sel: DatatypeSelector) -> DatatypeSelector;
 }
 unsafe extern "C" {
     #[doc = " Release copy of datatype selector, decrements reference counter of `sel`.\n\n @param sel The datatype selector to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a\n       Cvc5DatatypeSelector returns a copy that is owned by the callee of the\n       function and thus, can be released."]
-    pub fn cvc5_dt_sel_release(sel: Cvc5DatatypeSelector);
+    #[link_name = "\u{1}cvc5_dt_sel_release"]
+    pub fn dt_sel_release(sel: DatatypeSelector);
 }
 unsafe extern "C" {
     #[doc = " Compare two datatype selectors for structural equality.\n @param a The first datatype selector.\n @param b The second datatype selector.\n @return True if the datatype selectors are equal."]
-    pub fn cvc5_dt_sel_is_equal(a: Cvc5DatatypeSelector, b: Cvc5DatatypeSelector) -> bool;
+    #[link_name = "\u{1}cvc5_dt_sel_is_equal"]
+    pub fn dt_sel_is_equal(a: DatatypeSelector, b: DatatypeSelector) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the name of a given datatype selector.\n @param sel The datatype selector.\n @return The name of the Datatype selector.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_sel_get_name(sel: Cvc5DatatypeSelector) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_sel_get_name"]
+    pub fn dt_sel_get_name(sel: DatatypeSelector) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the selector term of a given datatype selector.\n\n Selector terms are a class of function-like terms of selector\n sort (cvc5_sort_is_dt_selector()), and should be used as the first\n argument of Terms of kind #CVC5_KIND_APPLY_SELECTOR.\n\n @param sel The datatype selector.\n @return The selector term."]
-    pub fn cvc5_dt_sel_get_term(sel: Cvc5DatatypeSelector) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_dt_sel_get_term"]
+    pub fn dt_sel_get_term(sel: DatatypeSelector) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the updater term of a given datatype selector.\n\n Similar to selectors, updater terms are a class of function-like terms of\n updater Sort (cvc5_sort_is_dt_updater()), and should be used as the first\n argument of Terms of kind #CVC5_KIND_APPLY_UPDATER.\n\n @param sel The datatype selector.\n @return The updater term."]
-    pub fn cvc5_dt_sel_get_updater_term(sel: Cvc5DatatypeSelector) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_dt_sel_get_updater_term"]
+    pub fn dt_sel_get_updater_term(sel: DatatypeSelector) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the codomain sort of a given datatype selector.\n @param sel The datatype selector.\n @return The codomain sort of the selector."]
-    pub fn cvc5_dt_sel_get_codomain_sort(sel: Cvc5DatatypeSelector) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_dt_sel_get_codomain_sort"]
+    pub fn dt_sel_get_codomain_sort(sel: DatatypeSelector) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the string representation of a given datatype selector.\n @param sel The datatype selector.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_sel_to_string(sel: Cvc5DatatypeSelector) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_sel_to_string"]
+    pub fn dt_sel_to_string(sel: DatatypeSelector) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a datatype selector.\n @param sel The datatype selector.\n @return The hash value of the datatype selector."]
-    pub fn cvc5_dt_sel_hash(sel: Cvc5DatatypeSelector) -> usize;
+    #[link_name = "\u{1}cvc5_dt_sel_hash"]
+    pub fn dt_sel_hash(sel: DatatypeSelector) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of datatype constructor, increases reference counter of `cons`.\n\n @param cons The datatype constructor to copy.\n @return The same datatype constructor with its reference count increased by\n         one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_dt_cons_copy(cons: Cvc5DatatypeConstructor) -> Cvc5DatatypeConstructor;
+    #[link_name = "\u{1}cvc5_dt_cons_copy"]
+    pub fn dt_cons_copy(cons: DatatypeConstructor) -> DatatypeConstructor;
 }
 unsafe extern "C" {
     #[doc = " Release copy of datatype constructor, decrements reference counter of `cons`.\n\n @param cons The datatype constructor to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a\n       Cvc5DatatypeConstructor returns a copy that is owned by the callee of\n       the function and thus, can be released."]
-    pub fn cvc5_dt_cons_release(cons: Cvc5DatatypeConstructor);
+    #[link_name = "\u{1}cvc5_dt_cons_release"]
+    pub fn dt_cons_release(cons: DatatypeConstructor);
 }
 unsafe extern "C" {
     #[doc = " Compare two datatype constructors for structural equality.\n @param a The first datatype constructor.\n @param b The second datatype constructor.\n @return True if the datatype constructors are equal."]
-    pub fn cvc5_dt_cons_is_equal(a: Cvc5DatatypeConstructor, b: Cvc5DatatypeConstructor) -> bool;
+    #[link_name = "\u{1}cvc5_dt_cons_is_equal"]
+    pub fn dt_cons_is_equal(a: DatatypeConstructor, b: DatatypeConstructor) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the name of a given datatype constructor.\n @param cons The datatype constructor.\n @return The name.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_cons_get_name(cons: Cvc5DatatypeConstructor) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_cons_get_name"]
+    pub fn dt_cons_get_name(cons: DatatypeConstructor) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the constructor term of a given datatype constructor.\n\n Datatype constructors are a special class of function-like terms whose sort\n is datatype constructor (cvc5_sort_is_dt_constructor()). All datatype\n constructors, including nullary ones, should be used as the\n first argument to Terms whose kind is #CVC5_KIND_APPLY_CONSTRUCTOR.\n For example, the nil list can be constructed by\n `cvc5_mk_term(CVC5_KIND_APPLY_CONSTRUCTOR, {t})`, where `t` is the term\n returned by this function.\n\n @note This function should not be used for parametric datatypes. Instead,\n       use the function cvc5_dt_cons_get_instantiated_term() below.\n\n @param cons The datatype constructor.\n @return The constructor term."]
-    pub fn cvc5_dt_cons_get_term(cons: Cvc5DatatypeConstructor) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_dt_cons_get_term"]
+    pub fn dt_cons_get_term(cons: DatatypeConstructor) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the constructor term of this datatype constructor whose return\n type is `sort`.\n\n This function is intended to be used on constructors of parametric datatypes\n and can be seen as returning the constructor term that has been explicitly\n cast to the given sort.\n\n This function is required for constructors of parametric datatypes whose\n return type cannot be determined by type inference. For example, given:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-datatype List\n         (par (T) ((nil) (cons (head T) (tail (List T))))))\n \\endverbatim\n\n The type of nil terms must be provided by the user. In SMT version 2.6,\n this is done via the syntax for qualified identifiers:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (as nil (List Int))\n \\endverbatim\n\n This function is equivalent of applying the above, where the\n datatype constructor is the one corresponding to `nil`, and `sort` is\n `(List Int)`.\n\n @note The returned constructor term `t` is used to construct the above\n       (nullary) application of `nil` with\n       `cvc5_mk_term(CVC5_KIND_APPLY_CONSTRUCTOR, {t})`.\n\n @warning This function is experimental and may change in future versions.\n\n @param cons The datatype constructor.\n @param sort The desired return sort of the constructor.\n @return The constructor term."]
-    pub fn cvc5_dt_cons_get_instantiated_term(
-        cons: Cvc5DatatypeConstructor,
-        sort: Cvc5Sort,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_dt_cons_get_instantiated_term"]
+    pub fn dt_cons_get_instantiated_term(cons: DatatypeConstructor, sort: Sort) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the tester term of a given datatype constructor.\n\n Similar to constructors, testers are a class of function-like terms of\n tester sort (cvc5_sort_is_dt_constructor()) which should be used as the\n first argument of Terms of kind #CVC5_KIND_APPLY_TESTER.\n\n @param cons The datatype constructor.\n @return The tester term."]
-    pub fn cvc5_dt_cons_get_tester_term(cons: Cvc5DatatypeConstructor) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_dt_cons_get_tester_term"]
+    pub fn dt_cons_get_tester_term(cons: DatatypeConstructor) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the number of selectors of a given datatype constructor.\n @param cons The datatype constructor.\n @return The number of selectors."]
-    pub fn cvc5_dt_cons_get_num_selectors(cons: Cvc5DatatypeConstructor) -> usize;
+    #[link_name = "\u{1}cvc5_dt_cons_get_num_selectors"]
+    pub fn dt_cons_get_num_selectors(cons: DatatypeConstructor) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the selector at index `i` of a given datatype constructor.\n @param cons  The datatype constructor.\n @param index The index of the selector.\n @return The i^th DatatypeSelector."]
-    pub fn cvc5_dt_cons_get_selector(
-        cons: Cvc5DatatypeConstructor,
-        index: usize,
-    ) -> Cvc5DatatypeSelector;
+    #[link_name = "\u{1}cvc5_dt_cons_get_selector"]
+    pub fn dt_cons_get_selector(cons: DatatypeConstructor, index: usize) -> DatatypeSelector;
 }
 unsafe extern "C" {
     #[doc = " Get the datatype selector with the given name.\n @note This is a linear search through the selectors, so in case of\n       multiple, similarly-named selectors, the first is returned.\n @param cons The datatype constructor.\n @param name The name of the datatype selector.\n @return The first datatype selector with the given name."]
-    pub fn cvc5_dt_cons_get_selector_by_name(
-        cons: Cvc5DatatypeConstructor,
+    #[link_name = "\u{1}cvc5_dt_cons_get_selector_by_name"]
+    pub fn dt_cons_get_selector_by_name(
+        cons: DatatypeConstructor,
         name: *const ::std::os::raw::c_char,
-    ) -> Cvc5DatatypeSelector;
+    ) -> DatatypeSelector;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given datatype constructor.\n @param cons The datatype constructor.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_cons_to_string(cons: Cvc5DatatypeConstructor) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_cons_to_string"]
+    pub fn dt_cons_to_string(cons: DatatypeConstructor) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a datatype constructor.\n @param cons The datatype constructor.\n @return The hash value of the datatype constructor."]
-    pub fn cvc5_dt_cons_hash(cons: Cvc5DatatypeConstructor) -> usize;
+    #[link_name = "\u{1}cvc5_dt_cons_hash"]
+    pub fn dt_cons_hash(cons: DatatypeConstructor) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of datatype, increases reference counter of `dt`.\n\n @param dt The datatype to copy.\n @return The same datatype with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_dt_copy(dt: Cvc5Datatype) -> Cvc5Datatype;
+    #[link_name = "\u{1}cvc5_dt_copy"]
+    pub fn dt_copy(dt: Datatype) -> Datatype;
 }
 unsafe extern "C" {
     #[doc = " Release copy of datatype, decrements reference counter of `dt`.\n\n @param dt The datatype to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a\n       Cvc5Datatype returns a copy that is owned by the callee of the\n       function and thus, can be released."]
-    pub fn cvc5_dt_release(dt: Cvc5Datatype);
+    #[link_name = "\u{1}cvc5_dt_release"]
+    pub fn dt_release(dt: Datatype);
 }
 unsafe extern "C" {
     #[doc = " Compare two datatypes for structural equality.\n @param a The first datatype.\n @param b The second datatype.\n @return True if the datatypes are equal."]
-    pub fn cvc5_dt_is_equal(a: Cvc5Datatype, b: Cvc5Datatype) -> bool;
+    #[link_name = "\u{1}cvc5_dt_is_equal"]
+    pub fn dt_is_equal(a: Datatype, b: Datatype) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the datatype constructor of a given datatype at a given index.\n @param dt  The datatype.\n @param idx The index of the datatype constructor to return.\n @return The datatype constructor with the given index."]
-    pub fn cvc5_dt_get_constructor(dt: Cvc5Datatype, idx: usize) -> Cvc5DatatypeConstructor;
+    #[link_name = "\u{1}cvc5_dt_get_constructor"]
+    pub fn dt_get_constructor(dt: Datatype, idx: usize) -> DatatypeConstructor;
 }
 unsafe extern "C" {
     #[doc = " Get the datatype constructor of a given datatype with the given name.\n @note This is a linear search through the constructors, so in case of\n multiple, similarly-named constructors, the first is returned.\n @param dt  The datatype.\n @param name The name of the datatype constructor.\n @return The datatype constructor with the given name."]
-    pub fn cvc5_dt_get_constructor_by_name(
-        dt: Cvc5Datatype,
+    #[link_name = "\u{1}cvc5_dt_get_constructor_by_name"]
+    pub fn dt_get_constructor_by_name(
+        dt: Datatype,
         name: *const ::std::os::raw::c_char,
-    ) -> Cvc5DatatypeConstructor;
+    ) -> DatatypeConstructor;
 }
 unsafe extern "C" {
     #[doc = " Get the datatype selector of a given datatype with the given name.\n @note This is a linear search through the constructors and their selectors,\n       so in case of multiple, similarly-named selectors, the first is\n       returned.\n @param dt   The datatype.\n @param name The name of the datatype selector.\n @return The datatype selector with the given name."]
-    pub fn cvc5_dt_get_selector(
-        dt: Cvc5Datatype,
-        name: *const ::std::os::raw::c_char,
-    ) -> Cvc5DatatypeSelector;
+    #[link_name = "\u{1}cvc5_dt_get_selector"]
+    pub fn dt_get_selector(dt: Datatype, name: *const ::std::os::raw::c_char) -> DatatypeSelector;
 }
 unsafe extern "C" {
     #[doc = " Get the name of a given datatype.\n @param dt   The datatype.\n @return The name.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_get_name(dt: Cvc5Datatype) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_get_name"]
+    pub fn dt_get_name(dt: Datatype) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the number of constructors of a given datatype.\n @param dt   The datatype.\n @return The number of constructors."]
-    pub fn cvc5_dt_get_num_constructors(dt: Cvc5Datatype) -> usize;
+    #[link_name = "\u{1}cvc5_dt_get_num_constructors"]
+    pub fn dt_get_num_constructors(dt: Datatype) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Get the parameters of a given datatype, if it is parametric.\n @note Asserts that this datatype is parametric.\n @warning This function is experimental and may change in future versions.\n @param dt The datatype.\n @param size The size of the resulting array.\n @return The parameters of this datatype."]
-    pub fn cvc5_dt_get_parameters(dt: Cvc5Datatype, size: *mut usize) -> *const Cvc5Sort;
+    #[link_name = "\u{1}cvc5_dt_get_parameters"]
+    pub fn dt_get_parameters(dt: Datatype, size: *mut usize) -> *const Sort;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given datatype is parametric.\n @warning This function is experimental and may change in future versions.\n @param dt The datatype.\n @return True if the datatype is parametric."]
-    pub fn cvc5_dt_is_parametric(dt: Cvc5Datatype) -> bool;
+    #[link_name = "\u{1}cvc5_dt_is_parametric"]
+    pub fn dt_is_parametric(dt: Datatype) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given datatype corresponds to a co-datatype.\n @param dt The datatype.\n @return True if the datatype corresponds to a co-datatype."]
-    pub fn cvc5_dt_is_codatatype(dt: Cvc5Datatype) -> bool;
+    #[link_name = "\u{1}cvc5_dt_is_codatatype"]
+    pub fn dt_is_codatatype(dt: Datatype) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given datatype corresponds to a tuple.\n @param dt The datatype.\n @return True if this datatype corresponds to a tuple."]
-    pub fn cvc5_dt_is_tuple(dt: Cvc5Datatype) -> bool;
+    #[link_name = "\u{1}cvc5_dt_is_tuple"]
+    pub fn dt_is_tuple(dt: Datatype) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given datatype corresponds to a record.\n @warning This function is experimental and may change in future versions.\n @param dt The datatype.\n @return True if the datatype corresponds to a record."]
-    pub fn cvc5_dt_is_record(dt: Cvc5Datatype) -> bool;
+    #[link_name = "\u{1}cvc5_dt_is_record"]
+    pub fn dt_is_record(dt: Datatype) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given datatype is finite.\n @param dt The datatype.\n @return True if the datatype is finite."]
-    pub fn cvc5_dt_is_finite(dt: Cvc5Datatype) -> bool;
+    #[link_name = "\u{1}cvc5_dt_is_finite"]
+    pub fn dt_is_finite(dt: Datatype) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given datatype is well-founded.\n\n If the datatype is not a codatatype, this returns false if there are no\n values of the datatype that are of finite size.\n\n @param dt The datatype.\n @return True if the datatype is well-founded."]
-    pub fn cvc5_dt_is_well_founded(dt: Cvc5Datatype) -> bool;
+    #[link_name = "\u{1}cvc5_dt_is_well_founded"]
+    pub fn dt_is_well_founded(dt: Datatype) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given datatype.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_dt_to_string(dt: Cvc5Datatype) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_dt_to_string"]
+    pub fn dt_to_string(dt: Datatype) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a datatype.\n @param dt The datatype.\n @return The hash value of the datatype."]
-    pub fn cvc5_dt_hash(dt: Cvc5Datatype) -> usize;
+    #[link_name = "\u{1}cvc5_dt_hash"]
+    pub fn dt_hash(dt: Datatype) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Add `rule` to the set of rules corresponding to `symbol` of a given grammar.\n @param grammar The grammar.\n @param symbol  The non-terminal to which the rule is added.\n @param rule The rule to add."]
-    pub fn cvc5_grammar_add_rule(grammar: Cvc5Grammar, symbol: Cvc5Term, rule: Cvc5Term);
+    #[link_name = "\u{1}cvc5_grammar_add_rule"]
+    pub fn grammar_add_rule(grammar: Grammar, symbol: Term, rule: Term);
 }
 unsafe extern "C" {
     #[doc = " Add `rules` to the set of rules corresponding to `symbol` of a given grammar.\n @param grammar The grammar.\n @param symbol The non-terminal to which the rules are added.\n @param size   The number of rules to add.\n @param rules The rules to add."]
-    pub fn cvc5_grammar_add_rules(
-        grammar: Cvc5Grammar,
-        symbol: Cvc5Term,
-        size: usize,
-        rules: *const Cvc5Term,
-    );
+    #[link_name = "\u{1}cvc5_grammar_add_rules"]
+    pub fn grammar_add_rules(grammar: Grammar, symbol: Term, size: usize, rules: *const Term);
 }
 unsafe extern "C" {
     #[doc = " Allow `symbol` to be an arbitrary constant of a given grammar.\n @param grammar The grammar.\n @param symbol The non-terminal allowed to be any constant."]
-    pub fn cvc5_grammar_add_any_constant(grammar: Cvc5Grammar, symbol: Cvc5Term);
+    #[link_name = "\u{1}cvc5_grammar_add_any_constant"]
+    pub fn grammar_add_any_constant(grammar: Grammar, symbol: Term);
 }
 unsafe extern "C" {
     #[doc = " Allow `symbol` to be any input variable of a given grammar to corresponding\n synth-fun/synth-inv with the same sort as `symbol`.\n @param grammar The grammar.\n @param symbol The non-terminal allowed to be any input variable."]
-    pub fn cvc5_grammar_add_any_variable(grammar: Cvc5Grammar, symbol: Cvc5Term);
+    #[link_name = "\u{1}cvc5_grammar_add_any_variable"]
+    pub fn grammar_add_any_variable(grammar: Grammar, symbol: Term);
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given grammar.\n @param grammar The grammar.\n @return A string representation of the grammar.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_grammar_to_string(grammar: Cvc5Grammar) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_grammar_to_string"]
+    pub fn grammar_to_string(grammar: Grammar) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Compare two grammars for referential equality.\n @param a The first grammar.\n @param b The second grammar.\n @return  True if both grammar pointers point to the same internal grammar\n          object."]
-    pub fn cvc5_grammar_is_equal(a: Cvc5Grammar, b: Cvc5Grammar) -> bool;
+    #[link_name = "\u{1}cvc5_grammar_is_equal"]
+    pub fn grammar_is_equal(a: Grammar, b: Grammar) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compare two grammars for referential disequality.\n @param a The first grammar.\n @param b The second grammar.\n @return  True if both grammar pointers point to different internal grammar\n          objects."]
-    pub fn cvc5_grammar_is_disequal(a: Cvc5Grammar, b: Cvc5Grammar) -> bool;
+    #[link_name = "\u{1}cvc5_grammar_is_disequal"]
+    pub fn grammar_is_disequal(a: Grammar, b: Grammar) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a grammar.\n @param grammar The grammar.\n @return The hash value of the grammar."]
-    pub fn cvc5_grammar_hash(grammar: Cvc5Grammar) -> usize;
+    #[link_name = "\u{1}cvc5_grammar_hash"]
+    pub fn grammar_hash(grammar: Grammar) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of grammar, increases reference counter of `grammar`.\n\n @param grammar The grammar to copy.\n @return The same grammar with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_grammar_copy(grammar: Cvc5Grammar) -> Cvc5Grammar;
+    #[link_name = "\u{1}cvc5_grammar_copy"]
+    pub fn grammar_copy(grammar: Grammar) -> Grammar;
 }
 unsafe extern "C" {
     #[doc = " Release copy of grammar, decrements reference counter of `grammar`.\n\n @param grammar The grammar to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a copy\n       that is owned by the callee of the function and thus, can be released."]
-    pub fn cvc5_grammar_release(grammar: Cvc5Grammar);
+    #[link_name = "\u{1}cvc5_grammar_release"]
+    pub fn grammar_release(grammar: Grammar);
 }
 unsafe extern "C" {
     #[doc = " Construct a new instance of a cvc5 term manager.\n @return The cvc5 term manager."]
-    pub fn cvc5_term_manager_new() -> *mut Cvc5TermManager;
+    #[link_name = "\u{1}cvc5_term_manager_new"]
+    pub fn term_manager_new() -> *mut TermManager;
 }
 unsafe extern "C" {
     #[doc = " Delete a cvc5 term manager instance.\n @param tm The term manager instance."]
-    pub fn cvc5_term_manager_delete(tm: *mut Cvc5TermManager);
+    #[link_name = "\u{1}cvc5_term_manager_delete"]
+    pub fn term_manager_delete(tm: *mut TermManager);
 }
 unsafe extern "C" {
     #[doc = " Release all managed references.\n\n This will free all memory used by any managed objects allocated by the\n term manager.\n\n @note This invalidates all managed objects created by the term manager.\n\n @param tm The term manager instance."]
-    pub fn cvc5_term_manager_release(tm: *mut Cvc5TermManager);
+    #[link_name = "\u{1}cvc5_term_manager_release"]
+    pub fn term_manager_release(tm: *mut TermManager);
 }
 unsafe extern "C" {
     #[doc = " Print the term manager statistics to the given file descriptor, suitable for\n usage in signal handlers.\n @param tm The term manager instance.\n @param fd The file descriptor."]
-    pub fn cvc5_term_manager_print_stats_safe(tm: *mut Cvc5TermManager, fd: ::std::os::raw::c_int);
+    #[link_name = "\u{1}cvc5_term_manager_print_stats_safe"]
+    pub fn term_manager_print_stats_safe(tm: *mut TermManager, fd: ::std::os::raw::c_int);
 }
 unsafe extern "C" {
     #[doc = " Get a snapshot of the current state of the statistic values of this term\n manager. The returned object is completely decoupled from the term manager\n and will not change when the term manager is used again.\n @param tm The term manager instance.\n @return A snapshot of the current state of the statistic values."]
-    pub fn cvc5_term_manager_get_statistics(tm: *mut Cvc5TermManager) -> Cvc5Statistics;
+    #[link_name = "\u{1}cvc5_term_manager_get_statistics"]
+    pub fn term_manager_get_statistics(tm: *mut TermManager) -> Statistics;
 }
 unsafe extern "C" {
     #[doc = " Get the Boolean sort.\n @param tm The term manager instance.\n @return Sort Boolean."]
-    pub fn cvc5_get_boolean_sort(tm: *mut Cvc5TermManager) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_get_boolean_sort"]
+    pub fn get_boolean_sort(tm: *mut TermManager) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the Integer sort.\n @param tm The term manager instance.\n @return Sort Integer."]
-    pub fn cvc5_get_integer_sort(tm: *mut Cvc5TermManager) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_get_integer_sort"]
+    pub fn get_integer_sort(tm: *mut TermManager) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the Real sort.\n @param tm The term manager instance.\n @return Sort Real."]
-    pub fn cvc5_get_real_sort(tm: *mut Cvc5TermManager) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_get_real_sort"]
+    pub fn get_real_sort(tm: *mut TermManager) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the regular expression sort.\n @param tm The term manager instance.\n @return Sort RegExp."]
-    pub fn cvc5_get_regexp_sort(tm: *mut Cvc5TermManager) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_get_regexp_sort"]
+    pub fn get_regexp_sort(tm: *mut TermManager) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the rounding mode sort.\n @param tm The term manager instance.\n @return The rounding mode sort."]
-    pub fn cvc5_get_rm_sort(tm: *mut Cvc5TermManager) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_get_rm_sort"]
+    pub fn get_rm_sort(tm: *mut TermManager) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the string sort.\n @param tm The term manager instance.\n @return Sort String."]
-    pub fn cvc5_get_string_sort(tm: *mut Cvc5TermManager) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_get_string_sort"]
+    pub fn get_string_sort(tm: *mut TermManager) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create an array sort.\n @param tm The term manager instance.\n @param index The array index sort.\n @param elem  The array element sort.\n @return The array sort."]
-    pub fn cvc5_mk_array_sort(
-        tm: *mut Cvc5TermManager,
-        index: Cvc5Sort,
-        elem: Cvc5Sort,
-    ) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_array_sort"]
+    pub fn mk_array_sort(tm: *mut TermManager, index: Sort, elem: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a bit-vector sort.\n @param tm The term manager instance.\n @param size The bit-width of the bit-vector sort.\n @return The bit-vector sort."]
-    pub fn cvc5_mk_bv_sort(tm: *mut Cvc5TermManager, size: u32) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_bv_sort"]
+    pub fn mk_bv_sort(tm: *mut TermManager, size: u32) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a floating-point sort.\n @param tm The term manager instance.\n @param exp The bit-width of the exponent of the floating-point sort.\n @param sig The bit-width of the significand of the floating-point sort."]
-    pub fn cvc5_mk_fp_sort(tm: *mut Cvc5TermManager, exp: u32, sig: u32) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_fp_sort"]
+    pub fn mk_fp_sort(tm: *mut TermManager, exp: u32, sig: u32) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a finite-field sort from a given string of\n base n.\n\n @param tm The term manager instance.\n @param size The modulus of the field. Must be prime.\n @param base The base of the string representation of `size`.\n @return The finite-field sort."]
-    pub fn cvc5_mk_ff_sort(
-        tm: *mut Cvc5TermManager,
-        size: *const ::std::os::raw::c_char,
-        base: u32,
-    ) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_ff_sort"]
+    pub fn mk_ff_sort(tm: *mut TermManager, size: *const ::std::os::raw::c_char, base: u32)
+    -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a datatype sort.\n @param tm   The term manager instance.\n @param decl The datatype declaration from which the sort is created.\n @return The datatype sort."]
-    pub fn cvc5_mk_dt_sort(tm: *mut Cvc5TermManager, decl: Cvc5DatatypeDecl) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_dt_sort"]
+    pub fn mk_dt_sort(tm: *mut TermManager, decl: DatatypeDecl) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a vector of datatype sorts.\n @note The names of the datatype declarations must be distinct.\n @param tm    The term manager instance.\n @param size  The number of datatype declarations.\n @param decls The datatype declarations from which the sort is created.\n @return The datatype sorts."]
-    pub fn cvc5_mk_dt_sorts(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_dt_sorts"]
+    pub fn mk_dt_sorts(
+        tm: *mut TermManager,
         size: usize,
-        decls: *const Cvc5DatatypeDecl,
-    ) -> *const Cvc5Sort;
+        decls: *const DatatypeDecl,
+    ) -> *const Sort;
 }
 unsafe extern "C" {
     #[doc = " Create function sort.\n @param tm    The term manager instance.\n @param size  The number of domain sorts.\n @param sorts The sort of the function arguments (the domain sorts).\n @param codomain The sort of the function return value.\n @return The function sort."]
-    pub fn cvc5_mk_fun_sort(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_fun_sort"]
+    pub fn mk_fun_sort(
+        tm: *mut TermManager,
         size: usize,
-        sorts: *const Cvc5Sort,
-        codomain: Cvc5Sort,
-    ) -> Cvc5Sort;
+        sorts: *const Sort,
+        codomain: Sort,
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a sort parameter.\n @warning This function is experimental and may change in future versions.\n @param tm     The term manager instance.\n @param symbol The name of the sort, may be NULL.\n @return The sort parameter."]
-    pub fn cvc5_mk_param_sort(
-        tm: *mut Cvc5TermManager,
-        symbol: *const ::std::os::raw::c_char,
-    ) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_param_sort"]
+    pub fn mk_param_sort(tm: *mut TermManager, symbol: *const ::std::os::raw::c_char) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a predicate sort.\n @note This is equivalent to calling mkFunctionSort() with the Boolean sort\n as the codomain.\n @param tm    The term manager instance.\n @param size  The number of sorts.\n @param sorts The list of sorts of the predicate.\n @return The predicate sort."]
-    pub fn cvc5_mk_predicate_sort(
-        tm: *mut Cvc5TermManager,
-        size: usize,
-        sorts: *const Cvc5Sort,
-    ) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_predicate_sort"]
+    pub fn mk_predicate_sort(tm: *mut TermManager, size: usize, sorts: *const Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a record sort\n @warning This function is experimental and may change in future versions.\n @param tm    The term manager instance.\n @param size  The number of fields of the record.\n @param names The names of the fields of the record.\n @param sorts The sorts of the fields of the record.\n @return The record sort."]
-    pub fn cvc5_mk_record_sort(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_record_sort"]
+    pub fn mk_record_sort(
+        tm: *mut TermManager,
         size: usize,
         names: *mut *const ::std::os::raw::c_char,
-        sorts: *const Cvc5Sort,
-    ) -> Cvc5Sort;
+        sorts: *const Sort,
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a set sort.\n @param tm   The term manager instance.\n @param sort The sort of the set elements.\n @return The set sort."]
-    pub fn cvc5_mk_set_sort(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_set_sort"]
+    pub fn mk_set_sort(tm: *mut TermManager, sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a bag sort.\n @param tm   The term manager instance.\n @param sort The sort of the bag elements.\n @return The bag sort."]
-    pub fn cvc5_mk_bag_sort(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_bag_sort"]
+    pub fn mk_bag_sort(tm: *mut TermManager, sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a sequence sort.\n @param tm   The term manager instance.\n @param sort The sort of the sequence elements.\n @return The sequence sort."]
-    pub fn cvc5_mk_sequence_sort(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_sequence_sort"]
+    pub fn mk_sequence_sort(tm: *mut TermManager, sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create an abstract sort. An abstract sort represents a sort for a given\n kind whose parameters and arguments are unspecified.\n\n The kind `k` must be the kind of a sort that can be abstracted, i.e., a\n sort that has indices or argument sorts. For example,\n #CVC5_SORT_KIND_ARRAY_SORT and #CVC5_SORT_KIND_BITVECTOR_SORT can be passed\n as the kind `k` to this function, while #CVC5_SORT_KIND_INTEGER_SORT and\n #CVC5_SORT_KIND_STRING_SORT cannot.\n\n @note Providing the kind #CVC5_SORT_KIND_ABSTRACT_SORT as an argument to\n       this function returns the (fully) unspecified sort, denoted `?`.\n\n @note Providing a kind `k` that has no indices and a fixed arity\n       of argument sorts will return the sort of kind `k` whose arguments are\n       the unspecified sort. For example,\n       `cvc5_mk_abstract_sort(tm, CVC5_SORT_KIND_ARRAY_SORT)` will return the\n       sort `(ARRAY_SORT ? ?)` instead of the abstract sort whose abstract\n       kind is #CVC5_SORT_KIND_ARRAY_SORT.\n\n @warning This function is experimental and may change in future versions.\n\n @param tm The term manager instance.\n @param k The kind of the abstract sort\n @return The abstract sort."]
-    pub fn cvc5_mk_abstract_sort(tm: *mut Cvc5TermManager, k: Cvc5SortKind) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_abstract_sort"]
+    pub fn mk_abstract_sort(tm: *mut TermManager, k: SortKind) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create an uninterpreted sort.\n @param tm The term manager instance.\n @param symbol The name of the sort, may be NULL.\n @return The uninterpreted sort."]
-    pub fn cvc5_mk_uninterpreted_sort(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_uninterpreted_sort"]
+    pub fn mk_uninterpreted_sort(
+        tm: *mut TermManager,
         symbol: *const ::std::os::raw::c_char,
-    ) -> Cvc5Sort;
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create an unresolved datatype sort.\n\n This is for creating yet unresolved sort placeholders for mutually\n recursive parametric datatypes.\n\n @param tm The term manager instance.\n @param symbol The symbol of the sort.\n @param arity The number of sort parameters of the sort.\n @return The unresolved sort.\n\n @warning This function is experimental and may change in future versions."]
-    pub fn cvc5_mk_unresolved_dt_sort(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_unresolved_dt_sort"]
+    pub fn mk_unresolved_dt_sort(
+        tm: *mut TermManager,
         symbol: *const ::std::os::raw::c_char,
         arity: usize,
-    ) -> Cvc5Sort;
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create an uninterpreted sort constructor sort.\n\n An uninterpreted sort constructor is an uninterpreted sort with arity > 0.\n\n @param tm The term manager instance.\n @param symbol The symbol of the sort.\n @param arity The arity of the sort (must be > 0)\n @return The uninterpreted sort constructor sort."]
-    pub fn cvc5_mk_uninterpreted_sort_constructor_sort(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_uninterpreted_sort_constructor_sort"]
+    pub fn mk_uninterpreted_sort_constructor_sort(
+        tm: *mut TermManager,
         arity: usize,
         symbol: *const ::std::os::raw::c_char,
-    ) -> Cvc5Sort;
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a tuple sort.\n @param tm The term manager instance.\n @param size The number of sorts.\n @param sorts The sorts of f the elements of the tuple.\n @return The tuple sort."]
-    pub fn cvc5_mk_tuple_sort(
-        tm: *mut Cvc5TermManager,
-        size: usize,
-        sorts: *const Cvc5Sort,
-    ) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_tuple_sort"]
+    pub fn mk_tuple_sort(tm: *mut TermManager, size: usize, sorts: *const Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create a nullable sort.\n @param tm The term manager instance.\n @param sort The sort of the element of the nullable.\n @return The nullable sort."]
-    pub fn cvc5_mk_nullable_sort(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Sort;
+    #[link_name = "\u{1}cvc5_mk_nullable_sort"]
+    pub fn mk_nullable_sort(tm: *mut TermManager, sort: Sort) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Create operator of Kind:\n   - #CVC5_KIND_BITVECTOR_EXTRACT\n   - #CVC5_KIND_BITVECTOR_REPEAT\n   - #CVC5_KIND_BITVECTOR_ROTATE_LEFT\n   - #CVC5_KIND_BITVECTOR_ROTATE_RIGHT\n   - #CVC5_KIND_BITVECTOR_SIGN_EXTEND\n   - #CVC5_KIND_BITVECTOR_ZERO_EXTEND\n   - #CVC5_KIND_DIVISIBLE\n   - #CVC5_KIND_FLOATINGPOINT_TO_FP_FROM_FP\n   - #CVC5_KIND_FLOATINGPOINT_TO_FP_FROM_IEEE_BV\n   - #CVC5_KIND_FLOATINGPOINT_TO_FP_FROM_REAL\n   - #CVC5_KIND_FLOATINGPOINT_TO_FP_FROM_SBV\n   - #CVC5_KIND_FLOATINGPOINT_TO_FP_FROM_UBV\n   - #CVC5_KIND_FLOATINGPOINT_TO_SBV\n   - #CVC5_KIND_FLOATINGPOINT_TO_UBV\n   - #CVC5_KIND_INT_TO_BITVECTOR\n   - #CVC5_KIND_TUPLE_PROJECT\n\n See `Cvc5Kind` for a description of the parameters.\n\n @param tm The term manager instance.\n @param kind The kind of the operator.\n @param size The number of indices of the operator.\n @param idxs The indices.\n\n @note If `idxs` is empty, the Cvc5Op simply wraps the Cvc5Kind. The Cvc5Kind\n can be used in cvc5_mk_term directly without creating a Cvc5Op first."]
-    pub fn cvc5_mk_op(
-        tm: *mut Cvc5TermManager,
-        kind: Cvc5Kind,
-        size: usize,
-        idxs: *const u32,
-    ) -> Cvc5Op;
+    #[link_name = "\u{1}cvc5_mk_op"]
+    pub fn mk_op(tm: *mut TermManager, kind: Kind, size: usize, idxs: *const u32) -> Op;
 }
 unsafe extern "C" {
     #[doc = " Create operator of kind:\n   - #CVC5_KIND_DIVISIBLE (to support arbitrary precision integers)\n\n See CKind for a description of the parameters.\n\n @param tm The term manager instance.\n @param kind The kind of the operator.\n @param arg The string argument to this operator."]
-    pub fn cvc5_mk_op_from_str(
-        tm: *mut Cvc5TermManager,
-        kind: Cvc5Kind,
+    #[link_name = "\u{1}cvc5_mk_op_from_str"]
+    pub fn mk_op_from_str(
+        tm: *mut TermManager,
+        kind: Kind,
         arg: *const ::std::os::raw::c_char,
-    ) -> Cvc5Op;
+    ) -> Op;
 }
 unsafe extern "C" {
     #[doc = " Create n-ary term of given kind.\n @param tm The term manager instance.\n @param kind The kind of the term.\n @param size The number of childrens.\n @param children The children of the term.\n @return The Term"]
-    pub fn cvc5_mk_term(
-        tm: *mut Cvc5TermManager,
-        kind: Cvc5Kind,
-        size: usize,
-        children: *const Cvc5Term,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_term"]
+    pub fn mk_term(tm: *mut TermManager, kind: Kind, size: usize, children: *const Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create n-ary term of given kind from a given operator.\n Create operators with `cvc5_mk_op()` and `cvc5_mk_op_from_str()`.\n @param tm The term manager instance.\n @param op The operator.\n @param size The number of children.\n @param children The children of the term.\n @return The Term."]
-    pub fn cvc5_mk_term_from_op(
-        tm: *mut Cvc5TermManager,
-        op: Cvc5Op,
+    #[link_name = "\u{1}cvc5_mk_term_from_op"]
+    pub fn mk_term_from_op(
+        tm: *mut TermManager,
+        op: Op,
         size: usize,
-        children: *const Cvc5Term,
-    ) -> Cvc5Term;
+        children: *const Term,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a tuple term.\n @param tm The term manager instance.\n @param size The number of elements in the tuple.\n @param terms The elements.\n @return The tuple Term."]
-    pub fn cvc5_mk_tuple(tm: *mut Cvc5TermManager, size: usize, terms: *const Cvc5Term)
-    -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_tuple"]
+    pub fn mk_tuple(tm: *mut TermManager, size: usize, terms: *const Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a nullable some term.\n @param tm The term manager instance.\n @param term The element value.\n @return the Element value wrapped in some constructor."]
-    pub fn cvc5_mk_nullable_some(tm: *mut Cvc5TermManager, term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_nullable_some"]
+    pub fn mk_nullable_some(tm: *mut TermManager, term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a selector for nullable term.\n @param tm The term manager instance.\n @param term A nullable term.\n @return The element value of the nullable term."]
-    pub fn cvc5_mk_nullable_val(tm: *mut Cvc5TermManager, term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_nullable_val"]
+    pub fn mk_nullable_val(tm: *mut TermManager, term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a null tester for a nullable term.\n @param tm The term manager instance.\n @param term A nullable term.\n @return A tester whether term is null."]
-    pub fn cvc5_mk_nullable_is_null(tm: *mut Cvc5TermManager, term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_nullable_is_null"]
+    pub fn mk_nullable_is_null(tm: *mut TermManager, term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a some tester for a nullable term.\n @param tm The term manager instance.\n @param term A nullable term.\n @return A tester whether term is some."]
-    pub fn cvc5_mk_nullable_is_some(tm: *mut Cvc5TermManager, term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_nullable_is_some"]
+    pub fn mk_nullable_is_some(tm: *mut TermManager, term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a constant representing an null of the given sort.\n @param tm The term manager instance.\n @param sort The sort of the Nullable element.\n @return The null constant."]
-    pub fn cvc5_mk_nullable_null(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_nullable_null"]
+    pub fn mk_nullable_null(tm: *mut TermManager, sort: Sort) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a term that lifts kind to nullable terms.\n\n Example:\n If we have the term ((_ nullable.lift +) x y),\n where x, y of type (Nullable Int), then\n kind would be ADD, and args would be [x, y].\n This function would return\n (nullable.lift (lambda ((a Int) (b Int)) (+ a b)) x y)\n\n @param tm The term manager instance.\n @param kind The lifted operator.\n @param size The number of arguments of the lifted operator.\n @param args The arguments of the lifted operator.\n @return A term of kind #CVC5_KIND_NULLABLE_LIFT where the first child\n         is a lambda expression, and the remaining children are\n         the original arguments."]
-    pub fn cvc5_mk_nullable_lift(
-        tm: *mut Cvc5TermManager,
-        kind: Cvc5Kind,
+    #[link_name = "\u{1}cvc5_mk_nullable_lift"]
+    pub fn mk_nullable_lift(
+        tm: *mut TermManager,
+        kind: Kind,
         size: usize,
-        args: *const Cvc5Term,
-    ) -> Cvc5Term;
+        args: *const Term,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a skolem.\n @param tm      The term manager instance.\n @param id      The skolem identifier.\n @param size    The number of arguments of the lifted operator.\n @param indices The indices of the skolem.\n @return The skolem."]
-    pub fn cvc5_mk_skolem(
-        tm: *mut Cvc5TermManager,
-        id: Cvc5SkolemId,
-        size: usize,
-        indices: *const Cvc5Term,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_skolem"]
+    pub fn mk_skolem(tm: *mut TermManager, id: SkolemId, size: usize, indices: *const Term)
+    -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the number of indices for a skolem id.\n @param tm The term manager instance.\n @param id The skolem id.\n @return The number of indices for the skolem id."]
-    pub fn cvc5_get_num_idxs_for_skolem_id(tm: *mut Cvc5TermManager, id: Cvc5SkolemId) -> usize;
+    #[link_name = "\u{1}cvc5_get_num_idxs_for_skolem_id"]
+    pub fn get_num_idxs_for_skolem_id(tm: *mut TermManager, id: SkolemId) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Create a Boolean true constant.\n @param tm The term manager instance.\n @return The true constant."]
-    pub fn cvc5_mk_true(tm: *mut Cvc5TermManager) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_true"]
+    pub fn mk_true(tm: *mut TermManager) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a Boolean false constant.\n @param tm The term manager instance.\n @return The false constant."]
-    pub fn cvc5_mk_false(tm: *mut Cvc5TermManager) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_false"]
+    pub fn mk_false(tm: *mut TermManager) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a Boolean constant.\n @param tm The term manager instance.\n @return The Boolean constant.\n @param val The value of the constant."]
-    pub fn cvc5_mk_boolean(tm: *mut Cvc5TermManager, val: bool) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_boolean"]
+    pub fn mk_boolean(tm: *mut TermManager, val: bool) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a constant representing the number Pi.\n @param tm The term manager instance.\n @return A constant representing Pi."]
-    pub fn cvc5_mk_pi(tm: *mut Cvc5TermManager) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_pi"]
+    pub fn mk_pi(tm: *mut TermManager) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create an integer constant from a string.\n @param tm The term manager instance.\n @param s The string representation of the constant, may represent an\n          integer (e.g., \"123\").\n @return A constant of sort Integer assuming `s` represents an integer)"]
-    pub fn cvc5_mk_integer(tm: *mut Cvc5TermManager, s: *const ::std::os::raw::c_char) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_integer"]
+    pub fn mk_integer(tm: *mut TermManager, s: *const ::std::os::raw::c_char) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create an integer constant from a c++ int.\n @param tm The term manager instance.\n @param val The value of the constant.\n @return A constant of sort Integer."]
-    pub fn cvc5_mk_integer_int64(tm: *mut Cvc5TermManager, val: i64) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_integer_int64"]
+    pub fn mk_integer_int64(tm: *mut TermManager, val: i64) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a real constant from a string.\n @param tm The term manager instance.\n @param s The string representation of the constant, may represent an\n          integer (e.g., \"123\") or real constant (e.g., \"12.34\" or \"12/34\").\n @return A constant of sort Real."]
-    pub fn cvc5_mk_real(tm: *mut Cvc5TermManager, s: *const ::std::os::raw::c_char) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_real"]
+    pub fn mk_real(tm: *mut TermManager, s: *const ::std::os::raw::c_char) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a real constant from an integer.\n @param tm The term manager instance.\n @param val The value of the constant.\n @return A constant of sort Integer."]
-    pub fn cvc5_mk_real_int64(tm: *mut Cvc5TermManager, val: i64) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_real_int64"]
+    pub fn mk_real_int64(tm: *mut TermManager, val: i64) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a real constant from a rational.\n @param tm The term manager instance.\n @param num The value of the numerator.\n @param den The value of the denominator.\n @return A constant of sort Real."]
-    pub fn cvc5_mk_real_num_den(tm: *mut Cvc5TermManager, num: i64, den: i64) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_real_num_den"]
+    pub fn mk_real_num_den(tm: *mut TermManager, num: i64, den: i64) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a regular expression all (re.all) term.\n @param tm The term manager instance.\n @return The all term."]
-    pub fn cvc5_mk_regexp_all(tm: *mut Cvc5TermManager) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_regexp_all"]
+    pub fn mk_regexp_all(tm: *mut TermManager) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a regular expression allchar (re.allchar) term.\n @param tm The term manager instance.\n @return The allchar term."]
-    pub fn cvc5_mk_regexp_allchar(tm: *mut Cvc5TermManager) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_regexp_allchar"]
+    pub fn mk_regexp_allchar(tm: *mut TermManager) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a regular expression none (re.none) term.\n @param tm The term manager instance.\n @return The none term."]
-    pub fn cvc5_mk_regexp_none(tm: *mut Cvc5TermManager) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_regexp_none"]
+    pub fn mk_regexp_none(tm: *mut TermManager) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a constant representing an empty set of the given sort.\n @param tm The term manager instance.\n @param sort The sort of the set elements.\n @return The empty set constant."]
-    pub fn cvc5_mk_empty_set(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_empty_set"]
+    pub fn mk_empty_set(tm: *mut TermManager, sort: Sort) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a constant representing an empty bag of the given sort.\n @param tm The term manager instance.\n @param sort The sort of the bag elements.\n @return The empty bag constant."]
-    pub fn cvc5_mk_empty_bag(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_empty_bag"]
+    pub fn mk_empty_bag(tm: *mut TermManager, sort: Sort) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a separation logic empty term.\n\n @warning This function is experimental and may change in future versions.\n\n @param tm The term manager instance.\n @return The separation logic empty term."]
-    pub fn cvc5_mk_sep_emp(tm: *mut Cvc5TermManager) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_sep_emp"]
+    pub fn mk_sep_emp(tm: *mut TermManager) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a separation logic nil term.\n\n @warning This function is experimental and may change in future versions.\n\n @param tm The term manager instance.\n @param sort The sort of the nil term.\n @return The separation logic nil term."]
-    pub fn cvc5_mk_sep_nil(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_sep_nil"]
+    pub fn mk_sep_nil(tm: *mut TermManager, sort: Sort) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a String constant from a regular character string which may contain\n SMT-LIB compatible escape sequences like `\\u1234` to encode unicode\n characters.\n @param tm The term manager instance.\n @param s The string this constant represents.\n @param use_esc_seq Determines whether escape sequences in `s` should.\n be converted to the corresponding unicode character\n @return The String constant."]
-    pub fn cvc5_mk_string(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_string"]
+    pub fn mk_string(
+        tm: *mut TermManager,
         s: *const ::std::os::raw::c_char,
         use_esc_seq: bool,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a String constant from a wide character string.\n This function does not support escape sequences as wide character already\n supports unicode characters.\n @param tm The term manager instance.\n @param s The string this constant represents.\n @return The String constant.\n\n @warning This function is deprecated and replaced by\n          cvc5_mk_string_from_char32(). It will be removed in a future\n          release."]
-    pub fn cvc5_mk_string_from_wchar(tm: *mut Cvc5TermManager, s: *const wchar_t) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_string_from_wchar"]
+    pub fn mk_string_from_wchar(tm: *mut TermManager, s: *const wchar_t) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a String constant from a UTF-32 string.\n This function does not support escape sequences as wide character already\n supports unicode characters.\n @param tm The term manager instance.\n @param s The UTF-32 string this constant represents.\n @return The String constant."]
-    pub fn cvc5_mk_string_from_char32(tm: *mut Cvc5TermManager, s: *const char32_t) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_string_from_char32"]
+    pub fn mk_string_from_char32(tm: *mut TermManager, s: *const char32_t) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create an empty sequence of the given element sort.\n @param tm The term manager instance.\n @param sort The element sort of the sequence.\n @return The empty sequence with given element sort."]
-    pub fn cvc5_mk_empty_sequence(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_empty_sequence"]
+    pub fn mk_empty_sequence(tm: *mut TermManager, sort: Sort) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a universe set of the given sort.\n @param tm The term manager instance.\n @param sort The sort of the set elements.\n @return The universe set constant."]
-    pub fn cvc5_mk_universe_set(tm: *mut Cvc5TermManager, sort: Cvc5Sort) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_universe_set"]
+    pub fn mk_universe_set(tm: *mut TermManager, sort: Sort) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a bit-vector constant of given size and value.\n\n @note The given value must fit into a bit-vector of the given size.\n\n @param tm The term manager instance.\n @param size The bit-width of the bit-vector sort.\n @param val The value of the constant.\n @return The bit-vector constant."]
-    pub fn cvc5_mk_bv_uint64(tm: *mut Cvc5TermManager, size: u32, val: u64) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_bv_uint64"]
+    pub fn mk_bv_uint64(tm: *mut TermManager, size: u32, val: u64) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a bit-vector constant of a given bit-width from a given string of\n base 2, 10 or 16.\n\n @note The given value must fit into a bit-vector of the given size.\n\n @param tm The term manager instance.\n @param size The bit-width of the constant.\n @param s The string representation of the constant.\n @param base The base of the string representation (`2` for binary, `10` for\n decimal, and `16` for hexadecimal).\n @return The bit-vector constant."]
-    pub fn cvc5_mk_bv(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_bv"]
+    pub fn mk_bv(
+        tm: *mut TermManager,
         size: u32,
         s: *const ::std::os::raw::c_char,
         base: u32,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a finite field constant in a given field from a given string\n of base n.\n\n @param tm    The term manager instance.\n @param value The string representation of the constant.\n @param sort  The field sort.\n @param base  The base of the string representation of `value`.\n\n If `size` is the field size, the constant needs not be in the range\n [0,size). If it is outside this range, it will be reduced modulo size\n before being constructed.\n"]
-    pub fn cvc5_mk_ff_elem(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_ff_elem"]
+    pub fn mk_ff_elem(
+        tm: *mut TermManager,
         value: *const ::std::os::raw::c_char,
-        sort: Cvc5Sort,
+        sort: Sort,
         base: u32,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a constant array with the provided constant value stored at every\n index.\n @param tm The term manager instance.\n @param sort The sort of the constant array (must be an array sort).\n @param val The constant value to store (must match the sort's element sort).\n @return The constant array term."]
-    pub fn cvc5_mk_const_array(tm: *mut Cvc5TermManager, sort: Cvc5Sort, val: Cvc5Term)
-    -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_const_array"]
+    pub fn mk_const_array(tm: *mut TermManager, sort: Sort, val: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a positive infinity floating-point constant (SMT-LIB: `+oo`).\n @param tm The term manager instance.\n @param exp Number of bits in the exponent.\n @param sig Number of bits in the significand.\n @return The floating-point constant."]
-    pub fn cvc5_mk_fp_pos_inf(tm: *mut Cvc5TermManager, exp: u32, sig: u32) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_fp_pos_inf"]
+    pub fn mk_fp_pos_inf(tm: *mut TermManager, exp: u32, sig: u32) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a negative infinity floating-point constant (SMT-LIB: `-oo`).\n @param tm The term manager instance.\n @param exp Number of bits in the exponent.\n @param sig Number of bits in the significand.\n @return The floating-point constant."]
-    pub fn cvc5_mk_fp_neg_inf(tm: *mut Cvc5TermManager, exp: u32, sig: u32) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_fp_neg_inf"]
+    pub fn mk_fp_neg_inf(tm: *mut TermManager, exp: u32, sig: u32) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a not-a-number floating-point constant (Cvc5TermManager* tm, SMT-LIB:\n `NaN`).\n @param tm The term manager instance.\n @param exp Number of bits in the exponent.\n @param sig Number of bits in the significand.\n @return The floating-point constant."]
-    pub fn cvc5_mk_fp_nan(tm: *mut Cvc5TermManager, exp: u32, sig: u32) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_fp_nan"]
+    pub fn mk_fp_nan(tm: *mut TermManager, exp: u32, sig: u32) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a positive zero floating-point constant (Cvc5TermManager* tm, SMT-LIB:\n +zero).\n @param tm The term manager instance.\n @param exp Number of bits in the exponent.\n @param sig Number of bits in the significand.\n @return The floating-point constant."]
-    pub fn cvc5_mk_fp_pos_zero(tm: *mut Cvc5TermManager, exp: u32, sig: u32) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_fp_pos_zero"]
+    pub fn mk_fp_pos_zero(tm: *mut TermManager, exp: u32, sig: u32) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a negative zero floating-point constant (Cvc5TermManager* tm, SMT-LIB:\n -zero).\n @param tm The term manager instance.\n @param exp Number of bits in the exponent.\n @param sig Number of bits in the significand.\n @return The floating-point constant."]
-    pub fn cvc5_mk_fp_neg_zero(tm: *mut Cvc5TermManager, exp: u32, sig: u32) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_fp_neg_zero"]
+    pub fn mk_fp_neg_zero(tm: *mut TermManager, exp: u32, sig: u32) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a rounding mode value.\n @param tm The term manager instance.\n @param rm The floating point rounding mode this constant represents.\n @return The rounding mode value."]
-    pub fn cvc5_mk_rm(tm: *mut Cvc5TermManager, rm: Cvc5RoundingMode) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_rm"]
+    pub fn mk_rm(tm: *mut TermManager, rm: RoundingMode) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a floating-point value from a bit-vector given in IEEE-754 format.\n @param tm The term manager instance.\n @param exp Size of the exponent.\n @param sig Size of the significand.\n @param val Value of the floating-point constant as a bit-vector term.\n @return The floating-point value."]
-    pub fn cvc5_mk_fp(tm: *mut Cvc5TermManager, exp: u32, sig: u32, val: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_fp"]
+    pub fn mk_fp(tm: *mut TermManager, exp: u32, sig: u32, val: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a floating-point value from its three IEEE-754 bit-vector\n value components (sign bit, exponent, significand).\n @param tm The term manager instance.\n @param sign The sign bit.\n @param exp  The bit-vector representing the exponent.\n @param sig The bit-vector representing the significand.\n @return The floating-point value."]
-    pub fn cvc5_mk_fp_from_ieee(
-        tm: *mut Cvc5TermManager,
-        sign: Cvc5Term,
-        exp: Cvc5Term,
-        sig: Cvc5Term,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_fp_from_ieee"]
+    pub fn mk_fp_from_ieee(tm: *mut TermManager, sign: Term, exp: Term, sig: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a cardinality constraint for an uninterpreted sort.\n\n @warning This function is experimental and may change in future versions.\n\n @param tm The term manager instance.\n @param sort The sort the cardinality constraint is for.\n @param upperBound The upper bound on the cardinality of the sort.\n @return The cardinality constraint."]
-    pub fn cvc5_mk_cardinality_constraint(
-        tm: *mut Cvc5TermManager,
-        sort: Cvc5Sort,
-        upperBound: u32,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_cardinality_constraint"]
+    pub fn mk_cardinality_constraint(tm: *mut TermManager, sort: Sort, upperBound: u32) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a free constant.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-const <symbol> <sort>)\n     (declare-fun <symbol> () <sort>)\n \\endverbatim\n\n @param tm The term manager instance.\n @param sort The sort of the constant.\n @param symbol The name of the constant, may be NULL.\n @return The constant."]
-    pub fn cvc5_mk_const(
-        tm: *mut Cvc5TermManager,
-        sort: Cvc5Sort,
+    #[link_name = "\u{1}cvc5_mk_const"]
+    pub fn mk_const(
+        tm: *mut TermManager,
+        sort: Sort,
         symbol: *const ::std::os::raw::c_char,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a bound variable to be used in a binder (i.e., a quantifier, a\n lambda, or a witness binder).\n @param tm The term manager instance.\n @param sort The sort of the variable.\n @param symbol The name of the variable, may be NULL.\n @return The variable."]
-    pub fn cvc5_mk_var(
-        tm: *mut Cvc5TermManager,
-        sort: Cvc5Sort,
-        symbol: *const ::std::os::raw::c_char,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_mk_var"]
+    pub fn mk_var(tm: *mut TermManager, sort: Sort, symbol: *const ::std::os::raw::c_char) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a datatype constructor declaration.\n @param tm The term manager instance.\n @param name The name of the datatype constructor.\n @return The DatatypeConstructorDecl."]
-    pub fn cvc5_mk_dt_cons_decl(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_dt_cons_decl"]
+    pub fn mk_dt_cons_decl(
+        tm: *mut TermManager,
         name: *const ::std::os::raw::c_char,
-    ) -> Cvc5DatatypeConstructorDecl;
+    ) -> DatatypeConstructorDecl;
 }
 unsafe extern "C" {
     #[doc = " Create a datatype declaration.\n @param tm The term manager instance.\n @param name The name of the datatype.\n @param is_codt True if a codatatype is to be constructed.\n @return The Cvc5DatatypeDecl."]
-    pub fn cvc5_mk_dt_decl(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_dt_decl"]
+    pub fn mk_dt_decl(
+        tm: *mut TermManager,
         name: *const ::std::os::raw::c_char,
         is_codt: bool,
-    ) -> Cvc5DatatypeDecl;
+    ) -> DatatypeDecl;
 }
 unsafe extern "C" {
     #[doc = " Create a datatype declaration.\n Create sorts parameter with `cvc5_mk_param_sort()`.\n\n @warning This function is experimental and may change in future versions.\n\n @param tm The term manager instance.\n @param name The name of the datatype.\n @param size The number of sort parameters.\n @param params A list of sort parameters.\n @param is_codt True if a codatatype is to be constructed.\n @return The Cvc5DatatypeDecl."]
-    pub fn cvc5_mk_dt_decl_with_params(
-        tm: *mut Cvc5TermManager,
+    #[link_name = "\u{1}cvc5_mk_dt_decl_with_params"]
+    pub fn mk_dt_decl_with_params(
+        tm: *mut TermManager,
         name: *const ::std::os::raw::c_char,
         size: usize,
-        params: *const Cvc5Sort,
+        params: *const Sort,
         is_codt: bool,
-    ) -> Cvc5DatatypeDecl;
+    ) -> DatatypeDecl;
 }
 #[repr(u32)]
 #[doc = " @}"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub enum Cvc5OptionInfoKind {
+pub enum OptionInfoKind {
     #[doc = " The empty option info, does not hold value information."]
     Void = 0,
     #[doc = " Information for option with boolean option value."]
@@ -2870,9 +3113,9 @@ pub enum Cvc5OptionInfoKind {
 #[doc = " \\verbatim embed:rst:leading-asterisk\n Holds information about a specific option, including its name, its\n aliases, whether the option was explicitly set by the user, and information\n concerning its value.\n It can be obtained via :cpp:func:`cvc5_get_option_info()` and allows for a\n more detailed inspection of options than :cpp:func:`cvc5_get_option()`.\n Union member ``info`` holds any of the following alternatives:\n\n - Neither of the following if the option holds no value (or the value has no\n   native type). In that case, the kind of the option will be denoted as\n   #CVC5_OPTION_INFO_VOID.\n - Struct ``BoolInfo`` if the option is of type ``bool``. It holds the current\n   value and the default value of the option. Option kind is denoted as\n   #CVC5_OPTION_INFO_BOOL.\n - Struct ``StringInfo`` if the option is of type ``const char*``. It holds\n   the current value and the default value of the option. Option kind is\n   denoted as #CVC5_OPTION_INFO_STR.\n - Struct ``IntInfo`` if the option is of type ``int64_t``. It holds the\n   current, default, minimum and maximum value of the option. Option kind is\n   denoted as #CVC5_OPTION_INFO_INT64.\n - Struct ``UIntInfo`` if the option is of type ``uint64_t``. It holds the\n   current, default, minimum and maximum value of the option. Option kind is\n   denoted as #CVC5_OPTION_INFO_UINT64.\n - Struct ``DoubleInfo`` if the option is of type ``double``. It holds the\n   current, default, minimum and maximum value of the option. Option kind is\n   denoted as #CVC5_OPTION_INFO_DOUBLE.\n - Struct ``ModeInfo`` if the option has modes. It holds the current and\n   default valuesof the option, as well as a list of valid modes. Option kind\n   is denoted as #CVC5_OPTION_INFO_MODES.\n\n \\endverbatim\n\n  @note A typedef alias with the same name is also available for convenience."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5OptionInfo {
+pub struct OptionInfo {
     #[doc = " The kind of the option info."]
-    pub kind: Cvc5OptionInfoKind,
+    pub kind: OptionInfoKind,
     #[doc = " The option name"]
     pub name: *const ::std::os::raw::c_char,
     #[doc = " The number of option name aliases"]
@@ -2890,20 +3133,20 @@ pub struct Cvc5OptionInfo {
     #[doc = " True if the option is a regular option\n @warning This field is deprecated and replaced by `category`. It will be\n          removed in a future release."]
     pub is_regular: bool,
     #[doc = " The category of this option."]
-    pub category: Cvc5OptionCategory,
-    pub info_bool: Cvc5OptionInfo_BoolInfo,
-    pub info_str: Cvc5OptionInfo_StringInfo,
-    pub info_int: Cvc5OptionInfo_IntInfo,
-    pub info_uint: Cvc5OptionInfo_UIntInfo,
-    pub info_double: Cvc5OptionInfo_DoubleInfo,
-    pub info_mode: Cvc5OptionInfo_ModeInfo,
+    pub category: OptionCategory,
+    pub info_bool: OptionInfo_BoolInfo,
+    pub info_str: OptionInfo_StringInfo,
+    pub info_int: OptionInfo_IntInfo,
+    pub info_uint: OptionInfo_UIntInfo,
+    pub info_double: OptionInfo_DoubleInfo,
+    pub info_mode: OptionInfo_ModeInfo,
     #[doc = " The associated C++ info. For internal use, only."]
     pub d_cpp_info: *mut ::std::os::raw::c_void,
 }
 #[doc = " Information for boolean option values."]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct Cvc5OptionInfo_BoolInfo {
+pub struct OptionInfo_BoolInfo {
     #[doc = " The default value."]
     pub dflt: bool,
     #[doc = " The current value."]
@@ -2911,18 +3154,17 @@ pub struct Cvc5OptionInfo_BoolInfo {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5OptionInfo_BoolInfo"][::std::mem::size_of::<Cvc5OptionInfo_BoolInfo>() - 2usize];
-    ["Alignment of Cvc5OptionInfo_BoolInfo"]
-        [::std::mem::align_of::<Cvc5OptionInfo_BoolInfo>() - 1usize];
-    ["Offset of field: Cvc5OptionInfo_BoolInfo::dflt"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_BoolInfo, dflt) - 0usize];
-    ["Offset of field: Cvc5OptionInfo_BoolInfo::cur"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_BoolInfo, cur) - 1usize];
+    ["Size of OptionInfo_BoolInfo"][::std::mem::size_of::<OptionInfo_BoolInfo>() - 2usize];
+    ["Alignment of OptionInfo_BoolInfo"][::std::mem::align_of::<OptionInfo_BoolInfo>() - 1usize];
+    ["Offset of field: OptionInfo_BoolInfo::dflt"]
+        [::std::mem::offset_of!(OptionInfo_BoolInfo, dflt) - 0usize];
+    ["Offset of field: OptionInfo_BoolInfo::cur"]
+        [::std::mem::offset_of!(OptionInfo_BoolInfo, cur) - 1usize];
 };
 #[doc = " Information for string option values."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5OptionInfo_StringInfo {
+pub struct OptionInfo_StringInfo {
     #[doc = " The default value."]
     pub dflt: *const ::std::os::raw::c_char,
     #[doc = " The current value."]
@@ -2930,16 +3172,15 @@ pub struct Cvc5OptionInfo_StringInfo {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5OptionInfo_StringInfo"]
-        [::std::mem::size_of::<Cvc5OptionInfo_StringInfo>() - 16usize];
-    ["Alignment of Cvc5OptionInfo_StringInfo"]
-        [::std::mem::align_of::<Cvc5OptionInfo_StringInfo>() - 8usize];
-    ["Offset of field: Cvc5OptionInfo_StringInfo::dflt"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_StringInfo, dflt) - 0usize];
-    ["Offset of field: Cvc5OptionInfo_StringInfo::cur"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_StringInfo, cur) - 8usize];
+    ["Size of OptionInfo_StringInfo"][::std::mem::size_of::<OptionInfo_StringInfo>() - 16usize];
+    ["Alignment of OptionInfo_StringInfo"]
+        [::std::mem::align_of::<OptionInfo_StringInfo>() - 8usize];
+    ["Offset of field: OptionInfo_StringInfo::dflt"]
+        [::std::mem::offset_of!(OptionInfo_StringInfo, dflt) - 0usize];
+    ["Offset of field: OptionInfo_StringInfo::cur"]
+        [::std::mem::offset_of!(OptionInfo_StringInfo, cur) - 8usize];
 };
-impl Default for Cvc5OptionInfo_StringInfo {
+impl Default for OptionInfo_StringInfo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -2951,7 +3192,7 @@ impl Default for Cvc5OptionInfo_StringInfo {
 #[doc = " Information for int64 values."]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct Cvc5OptionInfo_IntInfo {
+pub struct OptionInfo_IntInfo {
     #[doc = " The default value."]
     pub dflt: i64,
     #[doc = " The current value."]
@@ -2967,26 +3208,25 @@ pub struct Cvc5OptionInfo_IntInfo {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5OptionInfo_IntInfo"][::std::mem::size_of::<Cvc5OptionInfo_IntInfo>() - 40usize];
-    ["Alignment of Cvc5OptionInfo_IntInfo"]
-        [::std::mem::align_of::<Cvc5OptionInfo_IntInfo>() - 8usize];
-    ["Offset of field: Cvc5OptionInfo_IntInfo::dflt"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_IntInfo, dflt) - 0usize];
-    ["Offset of field: Cvc5OptionInfo_IntInfo::cur"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_IntInfo, cur) - 8usize];
-    ["Offset of field: Cvc5OptionInfo_IntInfo::min"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_IntInfo, min) - 16usize];
-    ["Offset of field: Cvc5OptionInfo_IntInfo::max"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_IntInfo, max) - 24usize];
-    ["Offset of field: Cvc5OptionInfo_IntInfo::has_min"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_IntInfo, has_min) - 32usize];
-    ["Offset of field: Cvc5OptionInfo_IntInfo::has_max"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_IntInfo, has_max) - 33usize];
+    ["Size of OptionInfo_IntInfo"][::std::mem::size_of::<OptionInfo_IntInfo>() - 40usize];
+    ["Alignment of OptionInfo_IntInfo"][::std::mem::align_of::<OptionInfo_IntInfo>() - 8usize];
+    ["Offset of field: OptionInfo_IntInfo::dflt"]
+        [::std::mem::offset_of!(OptionInfo_IntInfo, dflt) - 0usize];
+    ["Offset of field: OptionInfo_IntInfo::cur"]
+        [::std::mem::offset_of!(OptionInfo_IntInfo, cur) - 8usize];
+    ["Offset of field: OptionInfo_IntInfo::min"]
+        [::std::mem::offset_of!(OptionInfo_IntInfo, min) - 16usize];
+    ["Offset of field: OptionInfo_IntInfo::max"]
+        [::std::mem::offset_of!(OptionInfo_IntInfo, max) - 24usize];
+    ["Offset of field: OptionInfo_IntInfo::has_min"]
+        [::std::mem::offset_of!(OptionInfo_IntInfo, has_min) - 32usize];
+    ["Offset of field: OptionInfo_IntInfo::has_max"]
+        [::std::mem::offset_of!(OptionInfo_IntInfo, has_max) - 33usize];
 };
 #[doc = " Information for uint64 values."]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct Cvc5OptionInfo_UIntInfo {
+pub struct OptionInfo_UIntInfo {
     #[doc = " The default value."]
     pub dflt: u64,
     #[doc = " The current value."]
@@ -3002,26 +3242,25 @@ pub struct Cvc5OptionInfo_UIntInfo {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5OptionInfo_UIntInfo"][::std::mem::size_of::<Cvc5OptionInfo_UIntInfo>() - 40usize];
-    ["Alignment of Cvc5OptionInfo_UIntInfo"]
-        [::std::mem::align_of::<Cvc5OptionInfo_UIntInfo>() - 8usize];
-    ["Offset of field: Cvc5OptionInfo_UIntInfo::dflt"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_UIntInfo, dflt) - 0usize];
-    ["Offset of field: Cvc5OptionInfo_UIntInfo::cur"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_UIntInfo, cur) - 8usize];
-    ["Offset of field: Cvc5OptionInfo_UIntInfo::min"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_UIntInfo, min) - 16usize];
-    ["Offset of field: Cvc5OptionInfo_UIntInfo::max"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_UIntInfo, max) - 24usize];
-    ["Offset of field: Cvc5OptionInfo_UIntInfo::has_min"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_UIntInfo, has_min) - 32usize];
-    ["Offset of field: Cvc5OptionInfo_UIntInfo::has_max"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_UIntInfo, has_max) - 33usize];
+    ["Size of OptionInfo_UIntInfo"][::std::mem::size_of::<OptionInfo_UIntInfo>() - 40usize];
+    ["Alignment of OptionInfo_UIntInfo"][::std::mem::align_of::<OptionInfo_UIntInfo>() - 8usize];
+    ["Offset of field: OptionInfo_UIntInfo::dflt"]
+        [::std::mem::offset_of!(OptionInfo_UIntInfo, dflt) - 0usize];
+    ["Offset of field: OptionInfo_UIntInfo::cur"]
+        [::std::mem::offset_of!(OptionInfo_UIntInfo, cur) - 8usize];
+    ["Offset of field: OptionInfo_UIntInfo::min"]
+        [::std::mem::offset_of!(OptionInfo_UIntInfo, min) - 16usize];
+    ["Offset of field: OptionInfo_UIntInfo::max"]
+        [::std::mem::offset_of!(OptionInfo_UIntInfo, max) - 24usize];
+    ["Offset of field: OptionInfo_UIntInfo::has_min"]
+        [::std::mem::offset_of!(OptionInfo_UIntInfo, has_min) - 32usize];
+    ["Offset of field: OptionInfo_UIntInfo::has_max"]
+        [::std::mem::offset_of!(OptionInfo_UIntInfo, has_max) - 33usize];
 };
 #[doc = " Information for double values."]
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-pub struct Cvc5OptionInfo_DoubleInfo {
+pub struct OptionInfo_DoubleInfo {
     #[doc = " The default value."]
     pub dflt: f64,
     #[doc = " The current value."]
@@ -3037,27 +3276,26 @@ pub struct Cvc5OptionInfo_DoubleInfo {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5OptionInfo_DoubleInfo"]
-        [::std::mem::size_of::<Cvc5OptionInfo_DoubleInfo>() - 40usize];
-    ["Alignment of Cvc5OptionInfo_DoubleInfo"]
-        [::std::mem::align_of::<Cvc5OptionInfo_DoubleInfo>() - 8usize];
-    ["Offset of field: Cvc5OptionInfo_DoubleInfo::dflt"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_DoubleInfo, dflt) - 0usize];
-    ["Offset of field: Cvc5OptionInfo_DoubleInfo::cur"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_DoubleInfo, cur) - 8usize];
-    ["Offset of field: Cvc5OptionInfo_DoubleInfo::min"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_DoubleInfo, min) - 16usize];
-    ["Offset of field: Cvc5OptionInfo_DoubleInfo::max"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_DoubleInfo, max) - 24usize];
-    ["Offset of field: Cvc5OptionInfo_DoubleInfo::has_min"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_DoubleInfo, has_min) - 32usize];
-    ["Offset of field: Cvc5OptionInfo_DoubleInfo::has_max"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_DoubleInfo, has_max) - 33usize];
+    ["Size of OptionInfo_DoubleInfo"][::std::mem::size_of::<OptionInfo_DoubleInfo>() - 40usize];
+    ["Alignment of OptionInfo_DoubleInfo"]
+        [::std::mem::align_of::<OptionInfo_DoubleInfo>() - 8usize];
+    ["Offset of field: OptionInfo_DoubleInfo::dflt"]
+        [::std::mem::offset_of!(OptionInfo_DoubleInfo, dflt) - 0usize];
+    ["Offset of field: OptionInfo_DoubleInfo::cur"]
+        [::std::mem::offset_of!(OptionInfo_DoubleInfo, cur) - 8usize];
+    ["Offset of field: OptionInfo_DoubleInfo::min"]
+        [::std::mem::offset_of!(OptionInfo_DoubleInfo, min) - 16usize];
+    ["Offset of field: OptionInfo_DoubleInfo::max"]
+        [::std::mem::offset_of!(OptionInfo_DoubleInfo, max) - 24usize];
+    ["Offset of field: OptionInfo_DoubleInfo::has_min"]
+        [::std::mem::offset_of!(OptionInfo_DoubleInfo, has_min) - 32usize];
+    ["Offset of field: OptionInfo_DoubleInfo::has_max"]
+        [::std::mem::offset_of!(OptionInfo_DoubleInfo, has_max) - 33usize];
 };
 #[doc = " Information for mode option values."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5OptionInfo_ModeInfo {
+pub struct OptionInfo_ModeInfo {
     #[doc = " The default value."]
     pub dflt: *const ::std::os::raw::c_char,
     #[doc = " The current value."]
@@ -3069,19 +3307,18 @@ pub struct Cvc5OptionInfo_ModeInfo {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5OptionInfo_ModeInfo"][::std::mem::size_of::<Cvc5OptionInfo_ModeInfo>() - 32usize];
-    ["Alignment of Cvc5OptionInfo_ModeInfo"]
-        [::std::mem::align_of::<Cvc5OptionInfo_ModeInfo>() - 8usize];
-    ["Offset of field: Cvc5OptionInfo_ModeInfo::dflt"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_ModeInfo, dflt) - 0usize];
-    ["Offset of field: Cvc5OptionInfo_ModeInfo::cur"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_ModeInfo, cur) - 8usize];
-    ["Offset of field: Cvc5OptionInfo_ModeInfo::num_modes"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_ModeInfo, num_modes) - 16usize];
-    ["Offset of field: Cvc5OptionInfo_ModeInfo::modes"]
-        [::std::mem::offset_of!(Cvc5OptionInfo_ModeInfo, modes) - 24usize];
+    ["Size of OptionInfo_ModeInfo"][::std::mem::size_of::<OptionInfo_ModeInfo>() - 32usize];
+    ["Alignment of OptionInfo_ModeInfo"][::std::mem::align_of::<OptionInfo_ModeInfo>() - 8usize];
+    ["Offset of field: OptionInfo_ModeInfo::dflt"]
+        [::std::mem::offset_of!(OptionInfo_ModeInfo, dflt) - 0usize];
+    ["Offset of field: OptionInfo_ModeInfo::cur"]
+        [::std::mem::offset_of!(OptionInfo_ModeInfo, cur) - 8usize];
+    ["Offset of field: OptionInfo_ModeInfo::num_modes"]
+        [::std::mem::offset_of!(OptionInfo_ModeInfo, num_modes) - 16usize];
+    ["Offset of field: OptionInfo_ModeInfo::modes"]
+        [::std::mem::offset_of!(OptionInfo_ModeInfo, modes) - 24usize];
 };
-impl Default for Cvc5OptionInfo_ModeInfo {
+impl Default for OptionInfo_ModeInfo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3092,44 +3329,41 @@ impl Default for Cvc5OptionInfo_ModeInfo {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5OptionInfo"][::std::mem::size_of::<Cvc5OptionInfo>() - 240usize];
-    ["Alignment of Cvc5OptionInfo"][::std::mem::align_of::<Cvc5OptionInfo>() - 8usize];
-    ["Offset of field: Cvc5OptionInfo::kind"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, kind) - 0usize];
-    ["Offset of field: Cvc5OptionInfo::name"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, name) - 8usize];
-    ["Offset of field: Cvc5OptionInfo::num_aliases"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, num_aliases) - 16usize];
-    ["Offset of field: Cvc5OptionInfo::aliases"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, aliases) - 24usize];
-    ["Offset of field: Cvc5OptionInfo::num_no_supports"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, num_no_supports) - 32usize];
-    ["Offset of field: Cvc5OptionInfo::no_supports"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, no_supports) - 40usize];
-    ["Offset of field: Cvc5OptionInfo::is_set_by_user"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, is_set_by_user) - 48usize];
-    ["Offset of field: Cvc5OptionInfo::is_expert"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, is_expert) - 49usize];
-    ["Offset of field: Cvc5OptionInfo::is_regular"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, is_regular) - 50usize];
-    ["Offset of field: Cvc5OptionInfo::category"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, category) - 52usize];
-    ["Offset of field: Cvc5OptionInfo::info_bool"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, info_bool) - 56usize];
-    ["Offset of field: Cvc5OptionInfo::info_str"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, info_str) - 64usize];
-    ["Offset of field: Cvc5OptionInfo::info_int"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, info_int) - 80usize];
-    ["Offset of field: Cvc5OptionInfo::info_uint"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, info_uint) - 120usize];
-    ["Offset of field: Cvc5OptionInfo::info_double"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, info_double) - 160usize];
-    ["Offset of field: Cvc5OptionInfo::info_mode"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, info_mode) - 200usize];
-    ["Offset of field: Cvc5OptionInfo::d_cpp_info"]
-        [::std::mem::offset_of!(Cvc5OptionInfo, d_cpp_info) - 232usize];
+    ["Size of OptionInfo"][::std::mem::size_of::<OptionInfo>() - 240usize];
+    ["Alignment of OptionInfo"][::std::mem::align_of::<OptionInfo>() - 8usize];
+    ["Offset of field: OptionInfo::kind"][::std::mem::offset_of!(OptionInfo, kind) - 0usize];
+    ["Offset of field: OptionInfo::name"][::std::mem::offset_of!(OptionInfo, name) - 8usize];
+    ["Offset of field: OptionInfo::num_aliases"]
+        [::std::mem::offset_of!(OptionInfo, num_aliases) - 16usize];
+    ["Offset of field: OptionInfo::aliases"][::std::mem::offset_of!(OptionInfo, aliases) - 24usize];
+    ["Offset of field: OptionInfo::num_no_supports"]
+        [::std::mem::offset_of!(OptionInfo, num_no_supports) - 32usize];
+    ["Offset of field: OptionInfo::no_supports"]
+        [::std::mem::offset_of!(OptionInfo, no_supports) - 40usize];
+    ["Offset of field: OptionInfo::is_set_by_user"]
+        [::std::mem::offset_of!(OptionInfo, is_set_by_user) - 48usize];
+    ["Offset of field: OptionInfo::is_expert"]
+        [::std::mem::offset_of!(OptionInfo, is_expert) - 49usize];
+    ["Offset of field: OptionInfo::is_regular"]
+        [::std::mem::offset_of!(OptionInfo, is_regular) - 50usize];
+    ["Offset of field: OptionInfo::category"]
+        [::std::mem::offset_of!(OptionInfo, category) - 52usize];
+    ["Offset of field: OptionInfo::info_bool"]
+        [::std::mem::offset_of!(OptionInfo, info_bool) - 56usize];
+    ["Offset of field: OptionInfo::info_str"]
+        [::std::mem::offset_of!(OptionInfo, info_str) - 64usize];
+    ["Offset of field: OptionInfo::info_int"]
+        [::std::mem::offset_of!(OptionInfo, info_int) - 80usize];
+    ["Offset of field: OptionInfo::info_uint"]
+        [::std::mem::offset_of!(OptionInfo, info_uint) - 120usize];
+    ["Offset of field: OptionInfo::info_double"]
+        [::std::mem::offset_of!(OptionInfo, info_double) - 160usize];
+    ["Offset of field: OptionInfo::info_mode"]
+        [::std::mem::offset_of!(OptionInfo, info_mode) - 200usize];
+    ["Offset of field: OptionInfo::d_cpp_info"]
+        [::std::mem::offset_of!(OptionInfo, d_cpp_info) - 232usize];
 };
-impl Default for Cvc5OptionInfo {
+impl Default for OptionInfo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3140,27 +3374,24 @@ impl Default for Cvc5OptionInfo {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given option info.\n @param info The option info.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_option_info_to_string(info: *const Cvc5OptionInfo)
-    -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_option_info_to_string"]
+    pub fn option_info_to_string(info: *const OptionInfo) -> *const ::std::os::raw::c_char;
 }
 #[doc = " A cvc5 plugin.\n\n @note A typedef alias with the same name is also available for convenience."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5Plugin {
+pub struct Plugin {
     #[doc = " Call to check, return list of lemmas to add to the SAT solver.\n This method is called periodically, roughly at every SAT decision.\n @param size  The size of the returned array of lemmas.\n @param state The state data for the function, may be NULL.\n @return The vector of lemmas to add to the SAT solver.\n @note This function pointer may be NULL to use the default implementation."]
     pub check: ::std::option::Option<
-        unsafe extern "C" fn(
-            size: *mut usize,
-            state: *mut ::std::os::raw::c_void,
-        ) -> *const Cvc5Term,
+        unsafe extern "C" fn(size: *mut usize, state: *mut ::std::os::raw::c_void) -> *const Term,
     >,
     #[doc = " Notify SAT clause, called when `clause` is learned by the SAT solver.\n @param clause The learned clause.\n @param state The state data for the function, may be NULL.\n @note This function pointer may be NULL to use the default implementation."]
     pub notify_sat_clause: ::std::option::Option<
-        unsafe extern "C" fn(clause: Cvc5Term, state: *mut ::std::os::raw::c_void),
+        unsafe extern "C" fn(clause: Term, state: *mut ::std::os::raw::c_void),
     >,
     #[doc = " Notify theory lemma, called when `lemma` is sent by a theory solver.\n @param lemma The theory lemma.\n @param state The state data for the function, may be NULL.\n @note This function pointer may be NULL to use the default implementation."]
     pub notify_theory_lemma: ::std::option::Option<
-        unsafe extern "C" fn(lemma: Cvc5Term, state: *mut ::std::os::raw::c_void),
+        unsafe extern "C" fn(lemma: Term, state: *mut ::std::os::raw::c_void),
     >,
     #[doc = " Get the name of the plugin (for debugging).\n @return The name of the plugin.\n @note This function pointer may NOT be NULL."]
     pub get_name: ::std::option::Option<unsafe extern "C" fn() -> *const ::std::os::raw::c_char>,
@@ -3173,23 +3404,22 @@ pub struct Cvc5Plugin {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Cvc5Plugin"][::std::mem::size_of::<Cvc5Plugin>() - 56usize];
-    ["Alignment of Cvc5Plugin"][::std::mem::align_of::<Cvc5Plugin>() - 8usize];
-    ["Offset of field: Cvc5Plugin::check"][::std::mem::offset_of!(Cvc5Plugin, check) - 0usize];
-    ["Offset of field: Cvc5Plugin::notify_sat_clause"]
-        [::std::mem::offset_of!(Cvc5Plugin, notify_sat_clause) - 8usize];
-    ["Offset of field: Cvc5Plugin::notify_theory_lemma"]
-        [::std::mem::offset_of!(Cvc5Plugin, notify_theory_lemma) - 16usize];
-    ["Offset of field: Cvc5Plugin::get_name"]
-        [::std::mem::offset_of!(Cvc5Plugin, get_name) - 24usize];
-    ["Offset of field: Cvc5Plugin::d_check_state"]
-        [::std::mem::offset_of!(Cvc5Plugin, d_check_state) - 32usize];
-    ["Offset of field: Cvc5Plugin::d_notify_sat_clause_state"]
-        [::std::mem::offset_of!(Cvc5Plugin, d_notify_sat_clause_state) - 40usize];
-    ["Offset of field: Cvc5Plugin::d_notify_theory_lemma_state"]
-        [::std::mem::offset_of!(Cvc5Plugin, d_notify_theory_lemma_state) - 48usize];
+    ["Size of Plugin"][::std::mem::size_of::<Plugin>() - 56usize];
+    ["Alignment of Plugin"][::std::mem::align_of::<Plugin>() - 8usize];
+    ["Offset of field: Plugin::check"][::std::mem::offset_of!(Plugin, check) - 0usize];
+    ["Offset of field: Plugin::notify_sat_clause"]
+        [::std::mem::offset_of!(Plugin, notify_sat_clause) - 8usize];
+    ["Offset of field: Plugin::notify_theory_lemma"]
+        [::std::mem::offset_of!(Plugin, notify_theory_lemma) - 16usize];
+    ["Offset of field: Plugin::get_name"][::std::mem::offset_of!(Plugin, get_name) - 24usize];
+    ["Offset of field: Plugin::d_check_state"]
+        [::std::mem::offset_of!(Plugin, d_check_state) - 32usize];
+    ["Offset of field: Plugin::d_notify_sat_clause_state"]
+        [::std::mem::offset_of!(Plugin, d_notify_sat_clause_state) - 40usize];
+    ["Offset of field: Plugin::d_notify_theory_lemma_state"]
+        [::std::mem::offset_of!(Plugin, d_notify_theory_lemma_state) - 48usize];
 };
-impl Default for Cvc5Plugin {
+impl Default for Plugin {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -3200,84 +3430,104 @@ impl Default for Cvc5Plugin {
 }
 unsafe extern "C" {
     #[doc = " Get the proof rule used by the root step of a given proof.\n @return The proof rule."]
-    pub fn cvc5_proof_get_rule(proof: Cvc5Proof) -> Cvc5ProofRule;
+    #[link_name = "\u{1}cvc5_proof_get_rule"]
+    pub fn proof_get_rule(proof: Proof) -> ProofRule;
 }
 unsafe extern "C" {
     #[doc = " Get the proof rewrite rule used  by the root step of the proof.\n\n Requires that `cvc5_proof_get_rule()` does not return\n #CVC5_PROOF_RULE_DSL_REWRITE or #CVC5_PROOF_RULE_THEORY_REWRITE.\n\n @param proof The proof.\n @return The proof rewrite rule."]
-    pub fn cvc5_proof_get_rewrite_rule(proof: Cvc5Proof) -> Cvc5ProofRewriteRule;
+    #[link_name = "\u{1}cvc5_proof_get_rewrite_rule"]
+    pub fn proof_get_rewrite_rule(proof: Proof) -> ProofRewriteRule;
 }
 unsafe extern "C" {
     #[doc = " Get the conclusion of the root step of a given proof.\n @param proof The proof.\n @return The conclusion term."]
-    pub fn cvc5_proof_get_result(proof: Cvc5Proof) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_proof_get_result"]
+    pub fn proof_get_result(proof: Proof) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the premises of the root step of a given proof.\n @param proof The proof.\n @param size  Output parameter to store the number of resulting premise\n              proofs.\n @return The premise proofs.\n @note The returned Cvc5Proof array pointer is only valid until the next call\n       to this function."]
-    pub fn cvc5_proof_get_children(proof: Cvc5Proof, size: *mut usize) -> *const Cvc5Proof;
+    #[link_name = "\u{1}cvc5_proof_get_children"]
+    pub fn proof_get_children(proof: Proof, size: *mut usize) -> *const Proof;
 }
 unsafe extern "C" {
     #[doc = " Get the arguments of the root step of a given proof.\n @param proof The proof.\n @param size  Output parameter to store the number of resulting argument\n              terms.\n @return The argument terms."]
-    pub fn cvc5_proof_get_arguments(proof: Cvc5Proof, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_proof_get_arguments"]
+    pub fn proof_get_arguments(proof: Proof, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Compare two proofs for referential equality.\n @param a The first proof.\n @param b The second proof.\n @return  True if both proof pointers point to the same internal proof object."]
-    pub fn cvc5_proof_is_equal(a: Cvc5Proof, b: Cvc5Proof) -> bool;
+    #[link_name = "\u{1}cvc5_proof_is_equal"]
+    pub fn proof_is_equal(a: Proof, b: Proof) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compare two proofs for referential disequality.\n @param a The first proof.\n @param b The second proof.\n @return  True if both proof pointers point to different internal proof\n          objects."]
-    pub fn cvc5_proof_is_disequal(a: Cvc5Proof, b: Cvc5Proof) -> bool;
+    #[link_name = "\u{1}cvc5_proof_is_disequal"]
+    pub fn proof_is_disequal(a: Proof, b: Proof) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Compute the hash value of a proof.\n @param proof The proof.\n @return The hash value of the proof."]
-    pub fn cvc5_proof_hash(proof: Cvc5Proof) -> usize;
+    #[link_name = "\u{1}cvc5_proof_hash"]
+    pub fn proof_hash(proof: Proof) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Make copy of proof, increases reference counter of `proof`.\n\n @param proof The proof to copy.\n @return The same proof with its reference count increased by one.\n\n @note This step is optional and allows users to manage resources in a more\n       fine-grained manner."]
-    pub fn cvc5_proof_copy(proof: Cvc5Proof) -> Cvc5Proof;
+    #[link_name = "\u{1}cvc5_proof_copy"]
+    pub fn proof_copy(proof: Proof) -> Proof;
 }
 unsafe extern "C" {
     #[doc = " Release copy of proof, decrements reference counter of `proof`.\n\n @param proof The proof to release.\n\n @note This step is optional and allows users to release resources in a more\n       fine-grained manner. Further, any API function that returns a copy\n       that is owned by the callee of the function and thus, can be released."]
-    pub fn cvc5_proof_release(proof: Cvc5Proof);
+    #[link_name = "\u{1}cvc5_proof_release"]
+    pub fn proof_release(proof: Proof);
 }
 unsafe extern "C" {
     #[doc = " Determine if a given statistic is intended for internal use only.\n @param stat The statistic.\n @return True if this is an internal statistic."]
-    pub fn cvc5_stat_is_internal(stat: Cvc5Stat) -> bool;
+    #[link_name = "\u{1}cvc5_stat_is_internal"]
+    pub fn stat_is_internal(stat: Stat) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given statistics statistic holds the default value.\n @param stat The statistic.\n @return True if this is a defaulted statistic."]
-    pub fn cvc5_stat_is_default(stat: Cvc5Stat) -> bool;
+    #[link_name = "\u{1}cvc5_stat_is_default"]
+    pub fn stat_is_default(stat: Stat) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given statistic holds an integer value.\n @param stat The statistic.\n @return True if this value is an integer."]
-    pub fn cvc5_stat_is_int(stat: Cvc5Stat) -> bool;
+    #[link_name = "\u{1}cvc5_stat_is_int"]
+    pub fn stat_is_int(stat: Stat) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the value of an integer statistic.\n @param stat The statistic.\n @return The integer value."]
-    pub fn cvc5_stat_get_int(stat: Cvc5Stat) -> i64;
+    #[link_name = "\u{1}cvc5_stat_get_int"]
+    pub fn stat_get_int(stat: Stat) -> i64;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given statistic holds a double value.\n @param stat The statistic.\n @return True if this value is a double."]
-    pub fn cvc5_stat_is_double(stat: Cvc5Stat) -> bool;
+    #[link_name = "\u{1}cvc5_stat_is_double"]
+    pub fn stat_is_double(stat: Stat) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the value of a double statistic.\n @param stat The statistic.\n @return The double value."]
-    pub fn cvc5_stat_get_double(stat: Cvc5Stat) -> f64;
+    #[link_name = "\u{1}cvc5_stat_get_double"]
+    pub fn stat_get_double(stat: Stat) -> f64;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given statistic holds a string value.\n @param stat The statistic.\n @return True if this value is a string."]
-    pub fn cvc5_stat_is_string(stat: Cvc5Stat) -> bool;
+    #[link_name = "\u{1}cvc5_stat_is_string"]
+    pub fn stat_is_string(stat: Stat) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get value of a string statistic.\n @param stat The statistic.\n @return The string value.\n @note The returned char pointer is only valid until the next call\n       to this function."]
-    pub fn cvc5_stat_get_string(stat: Cvc5Stat) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_stat_get_string"]
+    pub fn stat_get_string(stat: Stat) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Determine if a given statistic holds a histogram.\n @param stat The statistic.\n @return True if this value is a histogram."]
-    pub fn cvc5_stat_is_histogram(stat: Cvc5Stat) -> bool;
+    #[link_name = "\u{1}cvc5_stat_is_histogram"]
+    pub fn stat_is_histogram(stat: Stat) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the value of a histogram statistic.\n @param stat   The statistic.\n @param keys   The resulting arrays with the keys of the statistic, map to the\n               values given in the resulting `values` array..\n @param values The resulting arrays with the values of the statistic.\n @param size   The size of the resulting keys/values arrays."]
-    pub fn cvc5_stat_get_histogram(
-        stat: Cvc5Stat,
+    #[link_name = "\u{1}cvc5_stat_get_histogram"]
+    pub fn stat_get_histogram(
+        stat: Stat,
         keys: *mut *mut *const ::std::os::raw::c_char,
         values: *mut *mut u64,
         size: *mut usize,
@@ -3285,535 +3535,598 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given statistic.\n @param stat The statistic.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_stat_to_string(stat: Cvc5Stat) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_stat_to_string"]
+    pub fn stat_to_string(stat: Stat) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Initialize iteration over the statistics values.\n By default, only entries that are public and have been set\n are visible while the others are skipped.\n @param stat The statistics.\n @param internal If set to true, internal statistics are shown as well.\n @param dflt     If set to true, defaulted statistics are shown as well."]
-    pub fn cvc5_stats_iter_init(stat: Cvc5Statistics, internal: bool, dflt: bool);
+    #[link_name = "\u{1}cvc5_stats_iter_init"]
+    pub fn stats_iter_init(stat: Statistics, internal: bool, dflt: bool);
 }
 unsafe extern "C" {
     #[doc = " Determine if statistics iterator has more statitics to query.\n @note Requires that iterator was initialized with `cvc5_stats_iter_init()`.\n @param stat The statistics.\n @return True if the iterator has more statistics to query."]
-    pub fn cvc5_stats_iter_has_next(stat: Cvc5Statistics) -> bool;
+    #[link_name = "\u{1}cvc5_stats_iter_has_next"]
+    pub fn stats_iter_has_next(stat: Statistics) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get next statistic and increment iterator.\n @note Requires that iterator was initialized with `cvc5_stats_iter_init()`\n       and that `cvc5_stats_iter_has_next()`.\n @param stat The statistics.\n @param name The output parameter for the name of the returned statistic.\n             May be NULL to ignore.\n @note       The returned char* pointer are only valid until the next call to\n             this function.\n @return The next statistic."]
-    pub fn cvc5_stats_iter_next(
-        stat: Cvc5Statistics,
-        name: *mut *const ::std::os::raw::c_char,
-    ) -> Cvc5Stat;
+    #[link_name = "\u{1}cvc5_stats_iter_next"]
+    pub fn stats_iter_next(stat: Statistics, name: *mut *const ::std::os::raw::c_char) -> Stat;
 }
 unsafe extern "C" {
     #[doc = " Retrieve the statistic with the given name.\n @note Requires that a statistic with the given name actually exists.\n @param stat The statistics.\n @param name The name of the statistic.\n @return The statistic with the given name."]
-    pub fn cvc5_stats_get(stat: Cvc5Statistics, name: *const ::std::os::raw::c_char) -> Cvc5Stat;
+    #[link_name = "\u{1}cvc5_stats_get"]
+    pub fn stats_get(stat: Statistics, name: *const ::std::os::raw::c_char) -> Stat;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of a given statistics object.\n @param stat The statistics.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_stats_to_string(stat: Cvc5Statistics) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_stats_to_string"]
+    pub fn stats_to_string(stat: Statistics) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Construct a new instance of a cvc5 solver.\n @param tm The associated term manager instance.\n @return The cvc5 solver instance."]
-    pub fn cvc5_new(tm: *mut Cvc5TermManager) -> *mut Cvc5;
+    #[link_name = "\u{1}cvc5_new"]
+    pub fn new(tm: *mut TermManager) -> *mut Solver;
 }
 unsafe extern "C" {
     #[doc = " Delete a cvc5 solver instance.\n @param cvc5 The solver instance."]
-    pub fn cvc5_delete(cvc5: *mut Cvc5);
+    #[link_name = "\u{1}cvc5_delete"]
+    pub fn delete(cvc5: *mut Solver);
 }
 unsafe extern "C" {
     #[doc = " Get the associated term manager of a cvc5 solver instance.\n @param cvc5 The solver instance.\n @return The term manager."]
-    pub fn cvc5_get_tm(cvc5: *mut Cvc5) -> *mut Cvc5TermManager;
+    #[link_name = "\u{1}cvc5_get_tm"]
+    pub fn get_tm(cvc5: *mut Solver) -> *mut TermManager;
 }
 unsafe extern "C" {
     #[doc = " Create datatype sort.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-datatype <symbol> <datatype_decl>)\n \\endverbatim\n\n @param cvc5   The solver instance.\n @param symbol The name of the datatype sort.\n @param size The number of constructor declarations of the datatype sort.\n @param ctors The constructor declarations.\n @return The datatype sort."]
-    pub fn cvc5_declare_dt(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_declare_dt"]
+    pub fn declare_dt(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         size: usize,
-        ctors: *const Cvc5DatatypeConstructorDecl,
-    ) -> Cvc5Sort;
+        ctors: *const DatatypeConstructorDecl,
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Declare n-ary function symbol.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-fun <symbol> ( <sort>* ) <sort>)\n \\endverbatim\n\n @param cvc5   The solver instance.\n @param symbol The name of the function.\n @param size   The number of domain sorts of the function.\n @param sorts  The domain sorts of the function.\n @param sort   The codomain sort of the function.\n @param fresh  If true, then this method always returns a new Term. Otherwise,\n               this method will always return the same Term for each call with\n               the given sorts and symbol where fresh is false.\n @return The function."]
-    pub fn cvc5_declare_fun(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_declare_fun"]
+    pub fn declare_fun(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         size: usize,
-        sorts: *const Cvc5Sort,
-        sort: Cvc5Sort,
+        sorts: *const Sort,
+        sort: Sort,
         fresh: bool,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Declare uninterpreted sort.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-sort <symbol> <numeral>)\n \\endverbatim\n\n @note This corresponds to\n       `cvc5_mk_uninterpreted_sort()` if arity = 0, and to\n       `cvc5_mk_uninterpreted_sort_constructor_sort()` if arity > 0.\n\n @param cvc5   The solver instance.\n @param symbol The name of the sort.\n @param arity  The arity of the sort.\n @param fresh  If true, then this method always returns a new Sort.\n @return The sort."]
-    pub fn cvc5_declare_sort(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_declare_sort"]
+    pub fn declare_sort(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         arity: u32,
         fresh: bool,
-    ) -> Cvc5Sort;
+    ) -> Sort;
 }
 unsafe extern "C" {
     #[doc = " Define n-ary function.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (define-fun <function_def>)\n \\endverbatim\n\n @param cvc5   The cvc5 solver instance.\n @param symbol The name of the function.\n @param size   The number of parameters of the function.\n @param vars   The parameters.\n @param sort   The sort of the return value of this function.\n @param term   The function body.\n @param global Determines whether this definition is global (i.e., persists\n               when popping the context).\n @return The function."]
-    pub fn cvc5_define_fun(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_define_fun"]
+    pub fn define_fun(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         size: usize,
-        vars: *const Cvc5Term,
-        sort: Cvc5Sort,
-        term: Cvc5Term,
+        vars: *const Term,
+        sort: Sort,
+        term: Term,
         global: bool,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Define recursive function.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (define-fun-rec <function_def>)\n \\endverbatim\n\n @param cvc5   The cvc5 solver instance.\n @param symbol The name of the function.\n @param size   The number of parameters of the function.\n @param vars   The parameters to this function.\n @param sort   The sort of the return value of this function.\n @param term   The function body.\n @param global Determines whether this definition is global (i.e., persists\n               when popping the context).\n @return The function."]
-    pub fn cvc5_define_fun_rec(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_define_fun_rec"]
+    pub fn define_fun_rec(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         size: usize,
-        vars: *const Cvc5Term,
-        sort: Cvc5Sort,
-        term: Cvc5Term,
+        vars: *const Term,
+        sort: Sort,
+        term: Term,
         global: bool,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Define recursive function.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (define-fun-rec <function_def>)\n \\endverbatim\n\n Create parameter `fun` with mkConst().\n\n @param cvc5   The cvc5 solver instance.\n @param fun    The sorted function.\n @param size   The number of parameters of the function.\n @param vars   The parameters to this function.\n @param term   The function body.\n @param global Determines whether this definition is global (i.e., persists\n               when popping the context).\n @return The function."]
-    pub fn cvc5_define_fun_rec_from_const(
-        cvc5: *mut Cvc5,
-        fun: Cvc5Term,
+    #[link_name = "\u{1}cvc5_define_fun_rec_from_const"]
+    pub fn define_fun_rec_from_const(
+        cvc5: *mut Solver,
+        fun: Term,
         size: usize,
-        vars: *const Cvc5Term,
-        term: Cvc5Term,
+        vars: *const Term,
+        term: Term,
         global: bool,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Define recursive functions.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (define-funs-rec\n         ( <function_decl>_1 ... <function_decl>_n )\n         ( <term>_1 ... <term>_n )\n     )\n \\endverbatim\n\n Create elements of parameter `funs` with `cvc5_mk_const()`.\n\n @param cvc5   The cvc5 solver instance.\n @param nfuns  The number of sorted functions.\n @param funs   The sorted functions.\n @param nvars  The numbers of parameters for each function.\n @param vars   The list of parameters to the functions.\n @param terms  The list of function bodies of the functions.\n @param global Determines whether this definition is global (i.e., persists\n               when popping the context)."]
-    pub fn cvc5_define_funs_rec(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_define_funs_rec"]
+    pub fn define_funs_rec(
+        cvc5: *mut Solver,
         nfuns: usize,
-        funs: *const Cvc5Term,
+        funs: *const Term,
         nvars: *mut usize,
-        vars: *mut *const Cvc5Term,
-        terms: *const Cvc5Term,
+        vars: *mut *const Term,
+        terms: *const Term,
         global: bool,
     );
 }
 unsafe extern "C" {
     #[doc = " Simplify a formula without doing \"much\" work.\n\n Does not involve the SAT Engine in the simplification, but uses the\n current definitions, and assertions.  It also involves theory\n normalization.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5       The solver instance.\n @param term       The formula to simplify.\n @param apply_subs True to apply substitutions for solved variables.\n @return The simplified formula."]
-    pub fn cvc5_simplify(cvc5: *mut Cvc5, term: Cvc5Term, apply_subs: bool) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_simplify"]
+    pub fn simplify(cvc5: *mut Solver, term: Term, apply_subs: bool) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Assert a formula.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (assert <term>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param term The formula to assert."]
-    pub fn cvc5_assert_formula(cvc5: *mut Cvc5, term: Cvc5Term);
+    #[link_name = "\u{1}cvc5_assert_formula"]
+    pub fn assert_formula(cvc5: *mut Solver, term: Term);
 }
 unsafe extern "C" {
     #[doc = " Check satisfiability.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (check-sat)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @return The result of the satisfiability check."]
-    pub fn cvc5_check_sat(cvc5: *mut Cvc5) -> Cvc5Result;
+    #[link_name = "\u{1}cvc5_check_sat"]
+    pub fn check_sat(cvc5: *mut Solver) -> Result;
 }
 unsafe extern "C" {
     #[doc = " Check satisfiability assuming the given formulas.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (check-sat-assuming ( <prop_literal>+ ))\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param size The number of assumptions.\n @param assumptions The formulas to assume.\n @return The result of the satisfiability check."]
-    pub fn cvc5_check_sat_assuming(
-        cvc5: *mut Cvc5,
-        size: usize,
-        assumptions: *const Cvc5Term,
-    ) -> Cvc5Result;
+    #[link_name = "\u{1}cvc5_check_sat_assuming"]
+    pub fn check_sat_assuming(cvc5: *mut Solver, size: usize, assumptions: *const Term) -> Result;
 }
 unsafe extern "C" {
     #[doc = " Get the list of asserted formulas.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-assertions)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param size The size of the resulting assertions array.\n @return The list of asserted formulas.\n @note The returned Cvc5Term array pointer is only valid until the next call\n       to this function."]
-    pub fn cvc5_get_assertions(cvc5: *mut Cvc5, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_assertions"]
+    pub fn get_assertions(cvc5: *mut Solver, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get info from the solver.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-info <info_flag>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param flag The info flag.\n @return The info.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_get_info(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_info"]
+    pub fn get_info(
+        cvc5: *mut Solver,
         flag: *const ::std::os::raw::c_char,
     ) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the value of a given option.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-option <keyword>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param option The option for which the value is queried.\n @return A string representation of the option value.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_get_option(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_option"]
+    pub fn get_option(
+        cvc5: *mut Solver,
         option: *const ::std::os::raw::c_char,
     ) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get all option names that can be used with `cvc5_set_option()`,\n `cvc5_get_option()` and `cvc5_get_option_info()`.\n @param cvc5 The solver instance.\n @param size The size of the resulting option names array.\n @return All option names.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_get_option_names(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_option_names"]
+    pub fn get_option_names(
+        cvc5: *mut Solver,
         size: *mut usize,
     ) -> *mut *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get some information about a given option.\n See struct Cvc5OptionInfo for more details on which information is available.\n @param cvc5   The solver instance.\n @param option The option for which the info is queried.\n @param info   The output parameter for the queried info.\n @note The returned Cvc5OptionInfo data is only valid until the next call\n       to this function."]
-    pub fn cvc5_get_option_info(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_option_info"]
+    pub fn get_option_info(
+        cvc5: *mut Solver,
         option: *const ::std::os::raw::c_char,
-        info: *mut Cvc5OptionInfo,
+        info: *mut OptionInfo,
     );
 }
 unsafe extern "C" {
     #[doc = " Get the set of unsat (\"failed\") assumptions.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-unsat-assumptions)\n\n Requires to enable option\n :ref:`produce-unsat-assumptions <lbl-option-produce-unsat-assumptions>`.\n \\endverbatim\n\n @note The returned Cvc5Term array pointer is only valid until the next call\n       to this function.\n\n @param cvc5 The solver instance.\n @param size The number of the resulting unsat assumptions.\n @return The set of unsat assumptions."]
-    pub fn cvc5_get_unsat_assumptions(cvc5: *mut Cvc5, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_unsat_assumptions"]
+    pub fn get_unsat_assumptions(cvc5: *mut Solver, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get the unsatisfiable core.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-unsat-core)\n\n Requires to enable option\n :ref:`produce-unsat-cores <lbl-option-produce-unsat-cores>`.\n\n .. note::\n   In contrast to SMT-LIB, cvc5's API does not distinguish between named\n   and unnamed assertions when producing an unsatisfiable core.\n   Additionally, the API allows this option to be called after a check with\n   assumptions. A subset of those assumptions may be included in the\n   unsatisfiable core returned by this function.\n \\endverbatim\n\n @note The returned Cvc5Term array pointer is only valid until the next call\n       to this function.\n\n @param cvc5 The solver instance.\n @param size The size of the resulting unsat core.\n @return A set of terms representing the unsatisfiable core."]
-    pub fn cvc5_get_unsat_core(cvc5: *mut Cvc5, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_unsat_core"]
+    pub fn get_unsat_core(cvc5: *mut Solver, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get the lemmas used to derive unsatisfiability.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-unsat-core-lemmas)\n\n Requires the SAT proof unsat core mode, so to enable option\n :ref:`unsat-cores-mode=sat-proof <lbl-option-unsat-cores-mode>`.\n\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @note The returned Cvc5Term array pointer is only valid until the next call\n       to this function.\n\n @param cvc5 The solver instance.\n @param size The size of the resulting unsat core.\n @return A set of terms representing the lemmas used to derive\n         unsatisfiability."]
-    pub fn cvc5_get_unsat_core_lemmas(cvc5: *mut Cvc5, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_unsat_core_lemmas"]
+    pub fn get_unsat_core_lemmas(cvc5: *mut Solver, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get a difficulty estimate for an asserted formula. This function is\n intended to be called immediately after any response to a checkSat.\n\n @warning This function is experimental and may change in future versions.\n\n @note The resulting mapping from `inputs` (which is a subset of the inputs)\n to real `values` is an estimate of how difficult each assertion was to solve.\n Unmentioned assertions can be assumed to have zero difficulty.\n\n @param cvc5   The solver instance.\n @param size   The resulting size of `inputs` and `values`.\n @param inputs The resulting inputs that are mapped to the resulting `values`.\n @param values The resulting real values.\n\n @note The resulting `inputs` and `values` array pointers are only valid\n       until the next call to this function."]
-    pub fn cvc5_get_difficulty(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_difficulty"]
+    pub fn get_difficulty(
+        cvc5: *mut Solver,
         size: *mut usize,
-        inputs: *mut *mut Cvc5Term,
-        values: *mut *mut Cvc5Term,
+        inputs: *mut *mut Term,
+        values: *mut *mut Term,
     );
 }
 unsafe extern "C" {
     #[doc = " Get a timeout core.\n\n \\verbatim embed:rst:leading-asterisk\n This function computes a subset of the current assertions that cause a\n timeout. It may make multiple checks for satisfiability internally, each\n limited by the timeout value given by\n :ref:`timeout-core-timeout <lbl-option-timeout-core-timeout>`.\n\n If the result is unknown and the reason is timeout, then the list of\n formulas correspond to a subset of the current assertions that cause a\n timeout in the specified time :ref:`timeout-core-timeout\n <lbl-option-timeout-core-timeout>`. If the result is unsat, then the list of\n formulas correspond to an unsat core for the current assertions. Otherwise,\n the result is sat, indicating that the current assertions are satisfiable,\n and the returned set of assertions is empty.\n \\endverbatim\n\n @note This command  does not require being preceeded by a call to\n       `cvc5_check_sat()`.\n\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-timeout-core)\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5   The solver instance.\n @param result The resulting result.\n @param size   The resulting size of the timeout core.\n\n @return The list of assertions determined to be the timeout core. The\n         resulting result is stored in `result`.\n\n @note The resulting `result` and term array pointer are only valid\n       until the next call to this function."]
-    pub fn cvc5_get_timeout_core(
-        cvc5: *mut Cvc5,
-        result: *mut Cvc5Result,
+    #[link_name = "\u{1}cvc5_get_timeout_core"]
+    pub fn get_timeout_core(
+        cvc5: *mut Solver,
+        result: *mut Result,
         size: *mut usize,
-    ) -> *const Cvc5Term;
+    ) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get a timeout core of the given assumptions.\n\n This function computes a subset of the given assumptions that cause a\n timeout when added to the current assertions.\n\n \\verbatim embed:rst:leading-asterisk\n If the result is unknown and the reason is timeout, then the set of\n assumptions corresponds to a subset of the given assumptions that cause a\n timeout when added to the current assertions in the specified time\n :ref:`timeout-core-timeout <lbl-option-timeout-core-timeout>`. If the result\n is unsat, then the set of assumptions together with the current assertions\n correspond to an unsat core for the current assertions. Otherwise, the\n result is sat, indicating that the given assumptions plus the current\n assertions are satisfiable, and the returned set of assumptions is empty.\n \\endverbatim\n\n @note This command does not require being preceeded by a call to\n       `cvc5_check_sat()`.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-timeout-core (<assert>*))\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5        The solver instance.\n @param size        The number of assumptions.\n @param assumptions The (non-empty) set of formulas to assume.\n @param result      The resulting result.\n @param rsize       The resulting size of the timeout core.\n\n @return The list of assumptions determined to be the timeout core. The\n         resulting result is stored in `result`.\n\n @note The resulting `result` and term array pointer are only valid\n       until the next call to this function."]
-    pub fn cvc5_get_timeout_core_assuming(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_timeout_core_assuming"]
+    pub fn get_timeout_core_assuming(
+        cvc5: *mut Solver,
         size: usize,
-        assumptions: *const Cvc5Term,
-        result: *mut Cvc5Result,
+        assumptions: *const Term,
+        result: *mut Result,
         rsize: *mut usize,
-    ) -> *const Cvc5Term;
+    ) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get a proof associated with the most recent call to checkSat.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-proof :c)\n\n Requires to enable option\n :ref:`produce-proofs <lbl-option-produce-proofs>`.\n The string representation depends on the value of option\n :ref:`produce-proofs <lbl-option-proof-format-mode>`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param c    The component of the proof to return\n @param size The size of the resulting array of proofs.\n @return An array of proofs.\n\n @note The returned Cvc5Proof array pointer is only valid until the next call\n       to this function."]
-    pub fn cvc5_get_proof(
-        cvc5: *mut Cvc5,
-        c: Cvc5ProofComponent,
-        size: *mut usize,
-    ) -> *const Cvc5Proof;
+    #[link_name = "\u{1}cvc5_get_proof"]
+    pub fn get_proof(cvc5: *mut Solver, c: ProofComponent, size: *mut usize) -> *const Proof;
 }
 unsafe extern "C" {
     #[doc = " Get a list of learned literals that are entailed by the current set of\n assertions.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param type The type of learned literalsjto return\n @param size The size of the resulting list of literals.\n @return A list of literals that were learned at top-level.\n\n @note The resulting Cvc5Term array pointer is only valid until the next call\n       to this function."]
-    pub fn cvc5_get_learned_literals(
-        cvc5: *mut Cvc5,
-        type_: Cvc5LearnedLitType,
+    #[link_name = "\u{1}cvc5_get_learned_literals"]
+    pub fn get_learned_literals(
+        cvc5: *mut Solver,
+        type_: LearnedLitType,
         size: *mut usize,
-    ) -> *const Cvc5Term;
+    ) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get the value of the given term in the current model.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-value ( <term> ))\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param term The term for which the value is queried.\n @return The value of the given term."]
-    pub fn cvc5_get_value(cvc5: *mut Cvc5, term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_value"]
+    pub fn get_value(cvc5: *mut Solver, term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the values of the given terms in the current model.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-value ( <term>* ))\n \\endverbatim\n\n @param cvc5  The solver instance.\n @param size  The number of terms for which the value is queried.\n @param terms The terms.\n @param rsize The resulting size of the timeout core.\n @return The values of the given terms."]
-    pub fn cvc5_get_values(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_values"]
+    pub fn get_values(
+        cvc5: *mut Solver,
         size: usize,
-        terms: *const Cvc5Term,
+        terms: *const Term,
         rsize: *mut usize,
-    ) -> *const Cvc5Term;
+    ) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get the domain elements of uninterpreted sort s in the current model. The\n current model interprets s as the finite sort whose domain elements are\n given in the return value of this function.\n\n @param cvc5 The solver instance.\n @param sort The uninterpreted sort in question.\n @param size The size of the resulting domain elements array.\n @return The domain elements of s in the current model."]
-    pub fn cvc5_get_model_domain_elements(
-        cvc5: *mut Cvc5,
-        sort: Cvc5Sort,
+    #[link_name = "\u{1}cvc5_get_model_domain_elements"]
+    pub fn get_model_domain_elements(
+        cvc5: *mut Solver,
+        sort: Sort,
         size: *mut usize,
-    ) -> *const Cvc5Term;
+    ) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Determine if the model value of the given free constant was essential for\n showing satisfiability of the last `cvc5_check_sat()` query based on the\n current model.\n\n For any free constant `v`, this will only return false if\n \\verbatim embed:rst:inline :ref:`model-cores\n <lbl-option-model-cores>`\\endverbatim\n has been set to true.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param v The term in question.\n @return True if `v` was essential and is thus a model core symbol."]
-    pub fn cvc5_is_model_core_symbol(cvc5: *mut Cvc5, v: Cvc5Term) -> bool;
+    #[link_name = "\u{1}cvc5_is_model_core_symbol"]
+    pub fn is_model_core_symbol(cvc5: *mut Solver, v: Term) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the model\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-model)\n\n Requires to enable option\n :ref:`produce-models <lbl-option-produce-models>`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param nsorts The number of uninterpreted sorts that should be printed in\n              the model.\n @param sorts The list of uninterpreted sorts.\n @param nconsts The size of the list of free constants that should be printed\n                in the model.\n @param consts The list of free constants that should be printed in the\n             model. A subset of these may be printed based on\n             isModelCoreSymbol().\n @return A string representing the model.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_get_model(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_model"]
+    pub fn get_model(
+        cvc5: *mut Solver,
         nsorts: usize,
-        sorts: *const Cvc5Sort,
+        sorts: *const Sort,
         nconsts: usize,
-        consts: *const Cvc5Term,
+        consts: *const Term,
     ) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Do quantifier elimination.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-qe <q>)\n \\endverbatim\n\n @note Quantifier Elimination is is only complete for logics such as LRA,\n       LIA and BV.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param q A quantified formula of the form\n          @f$Q\\bar{x}_1... Q\\bar{x}_n. P( x_1...x_i, y_1...y_j)@f$\n          where\n          @f$Q\\bar{x}@f$ is a set of quantified variables of the form\n          @f$Q x_1...x_k@f$ and\n          @f$P( x_1...x_i, y_1...y_j )@f$ is a quantifier-free formula\n @return A formula @f$\\phi@f$  such that, given the current set of formulas\n         @f$A@f$ asserted to this solver:\n         - @f$(A \\wedge q)@f$ and @f$(A \\wedge \\phi)@f$ are equivalent\n         - @f$\\phi@f$ is quantifier-free formula containing only free\n           variables in @f$y_1...y_n@f$."]
-    pub fn cvc5_get_quantifier_elimination(cvc5: *mut Cvc5, q: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_quantifier_elimination"]
+    pub fn get_quantifier_elimination(cvc5: *mut Solver, q: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Do partial quantifier elimination, which can be used for incrementally\n computing the result of a quantifier elimination.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-qe-disjunct <q>)\n \\endverbatim\n\n @note Quantifier Elimination is is only complete for logics such as LRA,\n LIA and BV.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param q A quantified formula of the form\n          @f$Q\\bar{x}_1... Q\\bar{x}_n. P( x_1...x_i, y_1...y_j)@f$\n          where\n          @f$Q\\bar{x}@f$ is a set of quantified variables of the form\n          @f$Q x_1...x_k@f$ and\n          @f$P( x_1...x_i, y_1...y_j )@f$ is a quantifier-free formula\n @return A formula @f$\\phi@f$ such that, given the current set of formulas\n         @f$A@f$ asserted to this solver:\n         - @f$(A \\wedge q \\implies A \\wedge \\phi)@f$ if @f$Q@f$ is\n           @f$\\forall@f$, and @f$(A \\wedge \\phi \\implies A \\wedge q)@f$ if\n           @f$Q@f$ is @f$\\exists@f$\n         - @f$\\phi@f$ is quantifier-free formula containing only free\n           variables in @f$y_1...y_n@f$\n         - If @f$Q@f$ is @f$\\exists@f$, let @f$(A \\wedge Q_n)@f$ be the\n           formula\n           @f$(A \\wedge \\neg (\\phi \\wedge Q_1) \\wedge ... \\wedge\n           \\neg (\\phi \\wedge Q_n))@f$\n           where for each @f$i = 1...n@f$,\n           formula @f$(\\phi \\wedge Q_i)@f$ is the result of calling\n           cvc5_get_quantifier_elimination_disjunct() for @f$q@f$ with the\n           set of assertions @f$(A \\wedge Q_{i-1})@f$.\n           Similarly, if @f$Q@f$ is @f$\\forall@f$, then let\n           @f$(A \\wedge Q_n)@f$ be\n           @f$(A \\wedge (\\phi \\wedge Q_1) \\wedge ... \\wedge (\\phi \\wedge\n           Q_n))@f$\n           where @f$(\\phi \\wedge Q_i)@f$ is the same as above.\n           In either case, we have that @f$(\\phi \\wedge Q_j)@f$ will\n           eventually be true or false, for some finite j."]
-    pub fn cvc5_get_quantifier_elimination_disjunct(cvc5: *mut Cvc5, q: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_quantifier_elimination_disjunct"]
+    pub fn get_quantifier_elimination_disjunct(cvc5: *mut Solver, q: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " When using separation logic, this sets the location sort and the\n datatype sort to the given ones. This function should be invoked exactly\n once, before any separation logic constraints are provided.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param loc The location sort of the heap.\n @param data The data sort of the heap."]
-    pub fn cvc5_declare_sep_heap(cvc5: *mut Cvc5, loc: Cvc5Sort, data: Cvc5Sort);
+    #[link_name = "\u{1}cvc5_declare_sep_heap"]
+    pub fn declare_sep_heap(cvc5: *mut Solver, loc: Sort, data: Sort);
 }
 unsafe extern "C" {
     #[doc = " When using separation logic, obtain the term for the heap.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @return The term for the heap."]
-    pub fn cvc5_get_value_sep_heap(cvc5: *mut Cvc5) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_value_sep_heap"]
+    pub fn get_value_sep_heap(cvc5: *mut Solver) -> Term;
 }
 unsafe extern "C" {
     #[doc = " When using separation logic, obtain the term for nil.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @return The term for nil."]
-    pub fn cvc5_get_value_sep_nil(cvc5: *mut Cvc5) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_value_sep_nil"]
+    pub fn get_value_sep_nil(cvc5: *mut Solver) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Declare a symbolic pool of terms with the given initial value.\n\n For details on how pools are used to specify instructions for quantifier\n instantiation, see documentation for the #CVC5_KIND_INST_POOL kind.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-pool <symbol> <sort> ( <term>* ))\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param symbol The name of the pool.\n @param sort The sort of the elements of the pool.\n @param size The number of initial values of the pool.\n @param init_value The initial value of the pool.\n @return The pool symbol."]
-    pub fn cvc5_declare_pool(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_declare_pool"]
+    pub fn declare_pool(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
-        sort: Cvc5Sort,
+        sort: Sort,
         size: usize,
-        init_value: *const Cvc5Term,
-    ) -> Cvc5Term;
+        init_value: *const Term,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Declare an oracle function with reference to an implementation.\n\n Oracle functions have a different semantics with respect to ordinary\n declared functions. In particular, for an input to be satisfiable,\n its oracle functions are implicitly universally quantified.\n\n This function is used in part for implementing this command:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-oracle-fun <sym> (<sort>*) <sort> <sym>)\n \\endverbatim\n\n In particular, the above command is implemented by constructing a\n function over terms that wraps a call to binary sym via a text interface.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5   The solver instance.\n @param symbol The name of the oracle\n @param size   The number of domain sorts of the oracle function.\n @param sorts  The domain sorts.\n @param sort   The sort of the return value of this function.\n @param state  The state data for the oracle function, may be NULL.\n @param fun    The function that implements the oracle function, taking a\n               an array of term arguments and its size and a void pointer\n               to optionally capture any state data the function may need.\n @return The oracle function."]
-    pub fn cvc5_declare_oracle_fun(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_declare_oracle_fun"]
+    pub fn declare_oracle_fun(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         size: usize,
-        sorts: *const Cvc5Sort,
-        sort: Cvc5Sort,
+        sorts: *const Sort,
+        sort: Sort,
         state: *mut ::std::os::raw::c_void,
         fun: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: usize,
-                arg2: *const Cvc5Term,
+                arg2: *const Term,
                 arg3: *mut ::std::os::raw::c_void,
-            ) -> Cvc5Term,
+            ) -> Term,
         >,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Add plugin to this solver. Its callbacks will be called throughout the\n lifetime of this solver.\n @warning This function is experimental and may change in future versions.\n @param cvc5   The solver instance.\n @param plugin The plugin to add to this solver."]
-    pub fn cvc5_add_plugin(cvc5: *mut Cvc5, plugin: *mut Cvc5Plugin);
+    #[link_name = "\u{1}cvc5_add_plugin"]
+    pub fn add_plugin(cvc5: *mut Solver, plugin: *mut Plugin);
 }
 unsafe extern "C" {
     #[doc = " Get an interpolant.\n\n Given that @f$A \\rightarrow B@f$ is valid,\n this function determines a term @f$I@f$\n over the shared variables of @f$A@f$ and @f$B@f$,\n such that @f$A \\rightarrow I@f$ and\n @f$I \\rightarrow B@f$ are valid, if such a term exits. @f$A@f$ is the\n current set of assertions and @f$B@f$ is the conjecture, given as `conj`.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-interpolant <symbol> <conj>)\n\n .. note:: In SMT-LIB, `<symbol>` assigns a symbol to the interpolant.\n\n .. note:: Requires option\n          :ref:`produce-interpolants <lbl-option-produce-interpolants>` to\n          be set to a mode different from `none`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param conj The conjecture term.\n @return The interpolant, if an interpolant exists, else the null term."]
-    pub fn cvc5_get_interpolant(cvc5: *mut Cvc5, conj: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_interpolant"]
+    pub fn get_interpolant(cvc5: *mut Solver, conj: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get an interpolant\n\n Given that @f$A \\rightarrow B@f$ is valid,\n this function determines a term @f$I@f$\n over the shared variables of @f$A@f$ and @f$B@f$,\n with respect to a given grammar, such that\n @f$A \\rightarrow I@f$ and @f$I \\rightarrow B@f$ are valid, if such a term\n exits. @f$A@f$ is the current set of assertions and @f$B@f$ is the\n conjecture, given as `conj`.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-interpolant <symbol> <conj> <grammar>)\n\n .. note:: In SMT-LIB, `<symbol>` assigns a symbol to the interpolant.\n\n .. note:: Requires option\n          :ref:`produce-interpolants <lbl-option-produce-interpolants>` to\n          be set to a mode different from `none`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param conj The conjecture term.\n @param grammar The grammar for the interpolant I.\n @return The interpolant, if an interpolant exists, else the null term."]
-    pub fn cvc5_get_interpolant_with_grammar(
-        cvc5: *mut Cvc5,
-        conj: Cvc5Term,
-        grammar: Cvc5Grammar,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_interpolant_with_grammar"]
+    pub fn get_interpolant_with_grammar(cvc5: *mut Solver, conj: Term, grammar: Grammar) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the next interpolant. Can only be called immediately after a successful\n call to get-interpolant or get-interpolant-next. Is guaranteed to produce a\n syntactically different interpolant wrt the last returned interpolant if\n successful.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-interpolant-next)\n\n Requires to enable incremental mode, and option\n :ref:`produce-interpolants <lbl-option-produce-interpolants>` to be set to\n a mode different from `none`. \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @return A Term @f$I@f$ such that @f$A \\rightarrow I@f$ and\n         @f$I \\rightarrow B@f$ are valid, where @f$A@f$ is the\n         current set of assertions and @f$B@f$ is given in the input by\n         `conj`, or the null term if such a term cannot be found."]
-    pub fn cvc5_get_interpolant_next(cvc5: *mut Cvc5) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_interpolant_next"]
+    pub fn get_interpolant_next(cvc5: *mut Solver) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get an abduct.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-abduct <conj>)\n\n Requires to enable option\n :ref:`produce-abducts <lbl-option-produce-abducts>`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param conj The conjecture term.\n @return A term @f$C@f$ such that @f$(A \\wedge C)@f$ is satisfiable,\n         and @f$(A \\wedge \\neg B \\wedge C)@f$ is unsatisfiable, where\n         @f$A@f$ is the current set of assertions and @f$B@f$ is\n         given in the input by ``conj``, or the null term if such a term\n         cannot be found."]
-    pub fn cvc5_get_abduct(cvc5: *mut Cvc5, conj: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_abduct"]
+    pub fn get_abduct(cvc5: *mut Solver, conj: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get an abduct.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-abduct <conj> <grammar>)\n\n Requires to enable option\n :ref:`produce-abducts <lbl-option-produce-abducts>`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param conj The conjecture term.\n @param grammar The grammar for the abduct @f$C@f$\n @return A term C such that @f$(A \\wedge C)@f$ is satisfiable, and\n        @f$(A \\wedge \\neg B \\wedge C)@f$ is unsatisfiable, where @f$A@f$ is\n        the current set of assertions and @f$B@f$ is given in the input by\n        `conj`, or the null term if such a term cannot be found."]
-    pub fn cvc5_get_abduct_with_grammar(
-        cvc5: *mut Cvc5,
-        conj: Cvc5Term,
-        grammar: Cvc5Grammar,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_abduct_with_grammar"]
+    pub fn get_abduct_with_grammar(cvc5: *mut Solver, conj: Term, grammar: Grammar) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the next abduct. Can only be called immediately after a successful\n call to get-abduct or get-abduct-next. Is guaranteed to produce a\n syntactically different abduct wrt the last returned abduct if successful.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (get-abduct-next)\n\n Requires to enable incremental mode, and option\n :ref:`produce-abducts <lbl-option-produce-abducts>`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @return A term C such that @f$(A \\wedge C)@f$ is satisfiable, and\n        @f$(A \\wedge \\neg B \\wedge C)@f$ is unsatisfiable, where @f$A@f$ is\n        the current set of assertions and @f$B@f$ is given in the input by\n        the last call to getAbduct(), or the null term if such a term\n        cannot be found."]
-    pub fn cvc5_get_abduct_next(cvc5: *mut Cvc5) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_abduct_next"]
+    pub fn get_abduct_next(cvc5: *mut Solver) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Block the current model. Can be called only if immediately preceded by a\n SAT or INVALID query.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (block-model)\n\n Requires enabling option\n :ref:`produce-models <lbl-option-produce-models>`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @param mode The mode to use for blocking."]
-    pub fn cvc5_block_model(cvc5: *mut Cvc5, mode: Cvc5BlockModelsMode);
+    #[link_name = "\u{1}cvc5_block_model"]
+    pub fn block_model(cvc5: *mut Solver, mode: BlockModelsMode);
 }
 unsafe extern "C" {
     #[doc = " Block the current model values of (at least) the values in terms. Can be\n called only if immediately preceded by a SAT query.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (block-model-values ( <terms>+ ))\n\n Requires enabling option\n :ref:`produce-models <lbl-option-produce-models>`.\n \\endverbatim\n\n @warning This function is experimental and may change in future versions.\n @param cvc5 The solver instance.\n @param size The number of values to block.\n @param terms The values to block."]
-    pub fn cvc5_block_model_values(cvc5: *mut Cvc5, size: usize, terms: *const Cvc5Term);
+    #[link_name = "\u{1}cvc5_block_model_values"]
+    pub fn block_model_values(cvc5: *mut Solver, size: usize, terms: *const Term);
 }
 unsafe extern "C" {
     #[doc = " @warning This function is experimental and may change in future versions.\n\n @param cvc5 The solver instance.\n @return A string that contains information about all instantiations made\n         by the quantifiers module.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_get_instantiations(cvc5: *mut Cvc5) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_get_instantiations"]
+    pub fn get_instantiations(cvc5: *mut Solver) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Push (a) level(s) to the assertion stack.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (push <numeral>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param nscopes The number of levels to push."]
-    pub fn cvc5_push(cvc5: *mut Cvc5, nscopes: u32);
+    #[link_name = "\u{1}cvc5_push"]
+    pub fn push(cvc5: *mut Solver, nscopes: u32);
 }
 unsafe extern "C" {
     #[doc = " Pop (a) level(s) from the assertion stack.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (pop <numeral>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param nscopes The number of levels to pop."]
-    pub fn cvc5_pop(cvc5: *mut Cvc5, nscopes: u32);
+    #[link_name = "\u{1}cvc5_pop"]
+    pub fn pop(cvc5: *mut Solver, nscopes: u32);
 }
 unsafe extern "C" {
     #[doc = " Remove all assertions.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (reset-assertions)\n \\endverbatim\n\n @param cvc5 The solver instance."]
-    pub fn cvc5_reset_assertions(cvc5: *mut Cvc5);
+    #[link_name = "\u{1}cvc5_reset_assertions"]
+    pub fn reset_assertions(cvc5: *mut Solver);
 }
 unsafe extern "C" {
     #[doc = " Set info.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (set-info <attribute>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param keyword The info flag.\n @param value The value of the info flag."]
-    pub fn cvc5_set_info(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_set_info"]
+    pub fn set_info(
+        cvc5: *mut Solver,
         keyword: *const ::std::os::raw::c_char,
         value: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Set logic.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (set-logic <symbol>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param logic The logic to set."]
-    pub fn cvc5_set_logic(cvc5: *mut Cvc5, logic: *const ::std::os::raw::c_char);
+    #[link_name = "\u{1}cvc5_set_logic"]
+    pub fn set_logic(cvc5: *mut Solver, logic: *const ::std::os::raw::c_char);
 }
 unsafe extern "C" {
     #[doc = " Determine if `cvc5_set_logic()` has been called.\n\n @return True if `setLogic()` has already been called for the given solver\n         instance."]
-    pub fn cvc5_is_logic_set(cvc5: *mut Cvc5) -> bool;
+    #[link_name = "\u{1}cvc5_is_logic_set"]
+    pub fn is_logic_set(cvc5: *mut Solver) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the logic set the solver.\n @note Asserts `cvc5_is_logic_set()1.\n @return The logic used by the solver.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_get_logic(cvc5: *mut Cvc5) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_get_logic"]
+    pub fn get_logic(cvc5: *mut Solver) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Set option.\n\n SMT-LIB:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (set-option :<option> <value>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param option The option name.\n @param value The option value."]
-    pub fn cvc5_set_option(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_set_option"]
+    pub fn set_option(
+        cvc5: *mut Solver,
         option: *const ::std::os::raw::c_char,
         value: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Append \\p symbol to the current list of universal variables.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (declare-var <symbol> <sort>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param sort The sort of the universal variable.\n @param symbol The name of the universal variable.\n @return The universal variable."]
-    pub fn cvc5_declare_sygus_var(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_declare_sygus_var"]
+    pub fn declare_sygus_var(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
-        sort: Cvc5Sort,
-    ) -> Cvc5Term;
+        sort: Sort,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Create a Sygus grammar. The first non-terminal is treated as the starting\n non-terminal, so the order of non-terminals matters.\n\n @param cvc5        The solver instance.\n @param nbound_vars The number of bound variabls.\n @param bound_vars  The parameters to corresponding synth-fun/synth-inv.\n @param nsymbols    The number of symbols.\n @param symbols     The pre-declaration of the non-terminal symbols.\n @return The grammar."]
-    pub fn cvc5_mk_grammar(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_mk_grammar"]
+    pub fn mk_grammar(
+        cvc5: *mut Solver,
         nbound_vars: usize,
-        bound_vars: *const Cvc5Term,
+        bound_vars: *const Term,
         nsymbols: usize,
-        symbols: *const Cvc5Term,
-    ) -> Cvc5Grammar;
+        symbols: *const Term,
+    ) -> Grammar;
 }
 unsafe extern "C" {
     #[doc = " Synthesize n-ary function.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (synth-fun <symbol> ( <boundVars>* ) <sort>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param symbol The name of the function.\n @param size The number of parameters.\n @param bound_vars The parameters to this function.\n @param sort The sort of the return value of this function.\n @return The function."]
-    pub fn cvc5_synth_fun(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_synth_fun"]
+    pub fn synth_fun(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         size: usize,
-        bound_vars: *const Cvc5Term,
-        sort: Cvc5Sort,
-    ) -> Cvc5Term;
+        bound_vars: *const Term,
+        sort: Sort,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Synthesize n-ary function following specified syntactic constraints.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (synth-fun <symbol> ( <boundVars>* ) <sort> <grammar>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param symbol The name of the function.\n @param size The number of parameters.\n @param bound_vars The parameters to this function.\n @param sort The sort of the return value of this function.\n @param grammar The syntactic constraints.\n @return The function."]
-    pub fn cvc5_synth_fun_with_grammar(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_synth_fun_with_grammar"]
+    pub fn synth_fun_with_grammar(
+        cvc5: *mut Solver,
         symbol: *const ::std::os::raw::c_char,
         size: usize,
-        bound_vars: *const Cvc5Term,
-        sort: Cvc5Sort,
-        grammar: Cvc5Grammar,
-    ) -> Cvc5Term;
+        bound_vars: *const Term,
+        sort: Sort,
+        grammar: Grammar,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Add a forumla to the set of Sygus constraints.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (constraint <term>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param term The formula to add as a constraint."]
-    pub fn cvc5_add_sygus_constraint(cvc5: *mut Cvc5, term: Cvc5Term);
+    #[link_name = "\u{1}cvc5_add_sygus_constraint"]
+    pub fn add_sygus_constraint(cvc5: *mut Solver, term: Term);
 }
 unsafe extern "C" {
     #[doc = " Get the list of sygus constraints.\n\n @param cvc5 The solver instance.\n @param size The size of the resulting list of sygus constraints.\n @return The list of sygus constraints."]
-    pub fn cvc5_get_sygus_constraints(cvc5: *mut Cvc5, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_sygus_constraints"]
+    pub fn get_sygus_constraints(cvc5: *mut Solver, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Add a forumla to the set of Sygus assumptions.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (assume <term>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param term The formula to add as an assumption."]
-    pub fn cvc5_add_sygus_assume(cvc5: *mut Cvc5, term: Cvc5Term);
+    #[link_name = "\u{1}cvc5_add_sygus_assume"]
+    pub fn add_sygus_assume(cvc5: *mut Solver, term: Term);
 }
 unsafe extern "C" {
     #[doc = " Get the list of sygus assumptions.\n\n @param cvc5 The solver instance.\n @param size The size of the resulting list of sygus assumptions.\n @return The list of sygus assumptions."]
-    pub fn cvc5_get_sygus_assumptions(cvc5: *mut Cvc5, size: *mut usize) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_sygus_assumptions"]
+    pub fn get_sygus_assumptions(cvc5: *mut Solver, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Add a set of Sygus constraints to the current state that correspond to an\n invariant synthesis problem.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (inv-constraint <inv> <pre> <trans> <post>)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @param inv The function-to-synthesize.\n @param pre The pre-condition.\n @param trans The transition relation.\n @param post The post-condition."]
-    pub fn cvc5_add_sygus_inv_constraint(
-        cvc5: *mut Cvc5,
-        inv: Cvc5Term,
-        pre: Cvc5Term,
-        trans: Cvc5Term,
-        post: Cvc5Term,
+    #[link_name = "\u{1}cvc5_add_sygus_inv_constraint"]
+    pub fn add_sygus_inv_constraint(
+        cvc5: *mut Solver,
+        inv: Term,
+        pre: Term,
+        trans: Term,
+        post: Term,
     );
 }
 unsafe extern "C" {
     #[doc = " Try to find a solution for the synthesis conjecture corresponding to the\n current list of functions-to-synthesize, universal variables and\n constraints.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (check-synth)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @return The result of the check, which is \"solution\" if the check found a\n         solution in which case solutions are available via\n         getSynthSolutions, \"no solution\" if it was determined there is no\n         solution, or \"unknown\" otherwise."]
-    pub fn cvc5_check_synth(cvc5: *mut Cvc5) -> Cvc5SynthResult;
+    #[link_name = "\u{1}cvc5_check_synth"]
+    pub fn check_synth(cvc5: *mut Solver) -> SynthResult;
 }
 unsafe extern "C" {
     #[doc = " Try to find a next solution for the synthesis conjecture corresponding to\n the current list of functions-to-synthesize, universal variables and\n constraints. Must be called immediately after a successful call to\n check-synth or check-synth-next.\n\n @note Requires incremental mode.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (check-synth-next)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @return The result of the check, which is \"solution\" if the check found a\n         solution in which case solutions are available via\n         getSynthSolutions, \"no solution\" if it was determined there is no\n         solution, or \"unknown\" otherwise."]
-    pub fn cvc5_check_synth_next(cvc5: *mut Cvc5) -> Cvc5SynthResult;
+    #[link_name = "\u{1}cvc5_check_synth_next"]
+    pub fn check_synth_next(cvc5: *mut Solver) -> SynthResult;
 }
 unsafe extern "C" {
     #[doc = " Get the synthesis solution of the given term. This function should be\n called immediately after the solver answers unsat for sygus input.\n @param cvc5 The solver instance.\n @param term The term for which the synthesis solution is queried.\n @return The synthesis solution of the given term."]
-    pub fn cvc5_get_synth_solution(cvc5: *mut Cvc5, term: Cvc5Term) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_synth_solution"]
+    pub fn get_synth_solution(cvc5: *mut Solver, term: Term) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get the synthesis solutions of the given terms. This function should be\n called immediately after the solver answers unsat for sygus input.\n @param cvc5  The solver instance.\n @param size  The size of the terms array.\n @param terms The terms for which the synthesis solutions is queried.\n @return The synthesis solutions of the given terms."]
-    pub fn cvc5_get_synth_solutions(
-        cvc5: *mut Cvc5,
-        size: usize,
-        terms: *const Cvc5Term,
-    ) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_get_synth_solutions"]
+    pub fn get_synth_solutions(cvc5: *mut Solver, size: usize, terms: *const Term) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Find a target term of interest using sygus enumeration, with no provided\n grammar.\n\n The solver will infer which grammar to use in this call, which by default\n will be the grammars specified by the function(s)-to-synthesize in the\n current context.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (find-synth :target)\n \\endverbatim\n\n @param cvc5   The solver instance.\n @param target The identifier specifying what kind of term to find\n @return The result of the find, which is the null term if this call failed.\n\n @warning This function is experimental and may change in future versions."]
-    pub fn cvc5_find_synth(cvc5: *mut Cvc5, target: Cvc5FindSynthTarget) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_find_synth"]
+    pub fn find_synth(cvc5: *mut Solver, target: FindSynthTarget) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Find a target term of interest using sygus enumeration with a provided\n grammar.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (find-synth :target G)\n \\endverbatim\n\n @param cvc5    The solver instance.\n @param target  The identifier specifying what kind of term to find\n @param grammar The grammar for the term\n @return The result of the find, which is the null term if this call failed.\n\n @warning This function is experimental and may change in future versions."]
-    pub fn cvc5_find_synth_with_grammar(
-        cvc5: *mut Cvc5,
-        target: Cvc5FindSynthTarget,
-        grammar: Cvc5Grammar,
-    ) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_find_synth_with_grammar"]
+    pub fn find_synth_with_grammar(
+        cvc5: *mut Solver,
+        target: FindSynthTarget,
+        grammar: Grammar,
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Try to find a next target term of interest using sygus enumeration. Must\n be called immediately after a successful call to find-synth or\n find-synth-next.\n\n SyGuS v2:\n\n \\verbatim embed:rst:leading-asterisk\n .. code:: smtlib\n\n     (find-synth-next)\n \\endverbatim\n\n @param cvc5 The solver instance.\n @return The result of the find, which is the null term if this call failed.\n\n @warning This function is experimental and may change in future versions."]
-    pub fn cvc5_find_synth_next(cvc5: *mut Cvc5) -> Cvc5Term;
+    #[link_name = "\u{1}cvc5_find_synth_next"]
+    pub fn find_synth_next(cvc5: *mut Solver) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Get a snapshot of the current state of the statistic values of this\n solver. The returned object is completely decoupled from the solver and\n will not change when the solver is used again.\n @param cvc5 The solver instance.\n @return A snapshot of the current state of the statistic values."]
-    pub fn cvc5_get_statistics(cvc5: *mut Cvc5) -> Cvc5Statistics;
+    #[link_name = "\u{1}cvc5_get_statistics"]
+    pub fn get_statistics(cvc5: *mut Solver) -> Statistics;
 }
 unsafe extern "C" {
     #[doc = " Print the statistics to the given file descriptor, suitable for usage in\n signal handlers.\n @param cvc5 The solver instance.\n @param fd The file descriptor."]
-    pub fn cvc5_print_stats_safe(cvc5: *mut Cvc5, fd: ::std::os::raw::c_int);
+    #[link_name = "\u{1}cvc5_print_stats_safe"]
+    pub fn print_stats_safe(cvc5: *mut Solver, fd: ::std::os::raw::c_int);
 }
 unsafe extern "C" {
     #[doc = " Determines if the output stream for the given tag is enabled. Tags can be\n enabled with the `output` option (and `-o <tag>` on the command line).\n\n @note Requires that a valid tag is given.\n\n @param cvc5 The solver instance.\n @param tag  The output tag.\n @return True if the given tag is enabled."]
-    pub fn cvc5_is_output_on(cvc5: *mut Cvc5, tag: *const ::std::os::raw::c_char) -> bool;
+    #[link_name = "\u{1}cvc5_is_output_on"]
+    pub fn is_output_on(cvc5: *mut Solver, tag: *const ::std::os::raw::c_char) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Configure a file to write the output for a given tag.\n\n Tags can be enabled with the `output` option (and `-o <tag>` on the command\n line). Requires that the given tag is valid.\n\n @note Close file `filename` before reading via `cvc5_close_output()`.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5     The solver instance.\n @param tag      The output tag.\n @param filename The file to write the output to. Use `<stdout>` to configure\n                 to write to stdout."]
-    pub fn cvc5_get_output(
-        cvc5: *mut Cvc5,
+    #[link_name = "\u{1}cvc5_get_output"]
+    pub fn get_output(
+        cvc5: *mut Solver,
         tag: *const ::std::os::raw::c_char,
         filename: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Close output file configured for an output tag via `cvc5_get_output()`.\n\n @note This is required before reading the file.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5     The solver instance.\n @param filename The file to close."]
-    pub fn cvc5_close_output(cvc5: *mut Cvc5, filename: *const ::std::os::raw::c_char);
+    #[link_name = "\u{1}cvc5_close_output"]
+    pub fn close_output(cvc5: *mut Solver, filename: *const ::std::os::raw::c_char);
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of the version of this solver.\n @param cvc5 The solver instance.\n @return The version string.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_get_version(cvc5: *mut Cvc5) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_get_version"]
+    pub fn get_version(cvc5: *mut Solver) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Prints a proof as a string in a selected proof format mode.\n Other aspects of printing are taken from the solver options.\n\n @warning This function is experimental and may change in future versions.\n\n @param cvc5       The solver instance.\n @param proof      A proof, usually obtained from Solver::getProof().\n @param format     The proof format used to print the proof.  Must be\n                   `modes::ProofFormat::NONE` if the proof is from a component\n                   other than `modes::ProofComponent::FULL`.\n @param size       The number of assertions to names mappings given.\n @param assertions The list of assertions that are mapped to\n                   `assertions_names`. May be NULL if `assertions_size` is 0.\n @param names      The names of the `assertions` (1:1 mapping). May by NULL\n                   if `assertions` is NULL.\n\n @return The string representation of the proof in the given format.\n\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_proof_to_string(
-        cvc5: *mut Cvc5,
-        proof: Cvc5Proof,
-        format: Cvc5ProofFormat,
+    #[link_name = "\u{1}cvc5_proof_to_string"]
+    pub fn proof_to_string(
+        cvc5: *mut Solver,
+        proof: Proof,
+        format: ProofFormat,
         size: usize,
-        assertions: *const Cvc5Term,
+        assertions: *const Term,
         names: *mut *const ::std::os::raw::c_char,
     ) -> *const ::std::os::raw::c_char;
 }

--- a/cvc5-sys/prebuilt/parser_bindings.rs
+++ b/cvc5-sys/prebuilt/parser_bindings.rs
@@ -4,7 +4,7 @@ use super::*;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5SymbolManager {
+pub struct SymbolManager {
     _unused: [u8; 0],
 }
 #[repr(C)]
@@ -13,134 +13,150 @@ pub struct cvc5_cmd_t {
     _unused: [u8; 0],
 }
 #[doc = " Encapsulation of a command.\n\n Commands are constructed by the input parser and can be invoked on\n the solver and symbol manager."]
-pub type Cvc5Command = *mut cvc5_cmd_t;
+pub type Command = *mut cvc5_cmd_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct Cvc5InputParser {
+pub struct InputParser {
     _unused: [u8; 0],
 }
 unsafe extern "C" {
     #[doc = " Construct a new instance of a cvc5 symbol manager.\n @param tm The associated term manager instance.\n @return The cvc5 symbol manager instance."]
-    pub fn cvc5_symbol_manager_new(tm: *mut Cvc5TermManager) -> *mut Cvc5SymbolManager;
+    #[link_name = "\u{1}cvc5_symbol_manager_new"]
+    pub fn symbol_manager_new(tm: *mut TermManager) -> *mut SymbolManager;
 }
 unsafe extern "C" {
     #[doc = " Delete a cvc5 symbol manager instance.\n @param sm The symbol manager instance."]
-    pub fn cvc5_symbol_manager_delete(sm: *mut Cvc5SymbolManager);
+    #[link_name = "\u{1}cvc5_symbol_manager_delete"]
+    pub fn symbol_manager_delete(sm: *mut SymbolManager);
 }
 unsafe extern "C" {
     #[doc = " Determine if the logic of a given symbol manager has been set.\n @param sm The symbol manager instance.\n @return True if the logic has been set."]
-    pub fn cvc5_sm_is_logic_set(sm: *mut Cvc5SymbolManager) -> bool;
+    #[link_name = "\u{1}cvc5_sm_is_logic_set"]
+    pub fn sm_is_logic_set(sm: *mut SymbolManager) -> bool;
 }
 unsafe extern "C" {
     #[doc = " Get the logic configured for a given symbol manager.\n @note Asserts `cvc5_sm_is_logic_set()`.\n @param sm The symbol manager instance.\n @return The configured logic.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_sm_get_logic(sm: *mut Cvc5SymbolManager) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_sm_get_logic"]
+    pub fn sm_get_logic(sm: *mut SymbolManager) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the list of sorts that have been declared via `declare-sort` commands.\n These are the sorts that are printed as part of a response to a\n `get-model` command.\n\n @param sm   The symbol manager instance.\n @param size The size of the resulting sorts array.\n @return The declared sorts."]
-    pub fn cvc5_sm_get_declared_sorts(
-        sm: *mut Cvc5SymbolManager,
-        size: *mut usize,
-    ) -> *const Cvc5Sort;
+    #[link_name = "\u{1}cvc5_sm_get_declared_sorts"]
+    pub fn sm_get_declared_sorts(sm: *mut SymbolManager, size: *mut usize) -> *const Sort;
 }
 unsafe extern "C" {
     #[doc = " Get the list of terms that have been declared via `declare-fun` and\n `declare-const`. These are the terms that are printed in response to a\n `get-model` command.\n\n @param sm   The symbol manager instance.\n @param size The size of the resulting sorts array.\n @return The declared terms.terms"]
-    pub fn cvc5_sm_get_declared_terms(
-        sm: *mut Cvc5SymbolManager,
-        size: *mut usize,
-    ) -> *const Cvc5Term;
+    #[link_name = "\u{1}cvc5_sm_get_declared_terms"]
+    pub fn sm_get_declared_terms(sm: *mut SymbolManager, size: *mut usize) -> *const Term;
 }
 unsafe extern "C" {
     #[doc = " Get the named terms that have been given to them via the :named attribute.\n\n @param sm    The symbol manager instance.\n @param size  The resulting size of `terms` and `names`.\n @param terms The resulting term that are mapped to the resulting `names`.\n @param names The resulting names.\n\n @note The resulting `terms` and `names` array pointers are only valid\n       until the next call to this function."]
-    pub fn cvc5_sm_get_named_terms(
-        sm: *mut Cvc5SymbolManager,
+    #[link_name = "\u{1}cvc5_sm_get_named_terms"]
+    pub fn sm_get_named_terms(
+        sm: *mut SymbolManager,
         size: *mut usize,
-        terms: *mut *mut Cvc5Term,
+        terms: *mut *mut Term,
         names: *mut *mut *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Invoke a given command on the solver and symbol manager sm and return any\n resulting output as a string.\n @param cmd  The command to invoke.\n @param cvc5 The solver to invoke the command on.\n @param sm   The symbol manager to invoke the command on.\n @return The output of invoking the command.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_cmd_invoke(
-        cmd: Cvc5Command,
-        cvc5: *mut Cvc5,
-        sm: *mut Cvc5SymbolManager,
+    #[link_name = "\u{1}cvc5_cmd_invoke"]
+    pub fn cmd_invoke(
+        cmd: Command,
+        cvc5: *mut Solver,
+        sm: *mut SymbolManager,
     ) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get a string representation of this command.\n @param cmd  The command to invoke.\n @return The string representation.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_cmd_to_string(cmd: Cvc5Command) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_cmd_to_string"]
+    pub fn cmd_to_string(cmd: Command) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Get the name for a given command, e.g., \"assert\".\n @param cmd  The command to invoke.\n @return The name of the command.\n @note The returned char* pointer is only valid until the next call to this\n       function."]
-    pub fn cvc5_cmd_get_name(cmd: Cvc5Command) -> *const ::std::os::raw::c_char;
+    #[link_name = "\u{1}cvc5_cmd_get_name"]
+    pub fn cmd_get_name(cmd: Command) -> *const ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Construct a new instance of a cvc5 input parser.\n @param cvc5 The associated solver instance.\n @param sm   The associated symbol manager instance, contains a symbol table\n             that maps symbols to terms and sorts. Must have a logic that is\n             compatible with the solver. May be NULL to start with and\n             initially empty symbol manager.\n @return The cvc5 symbol manager instance."]
-    pub fn cvc5_parser_new(cvc5: *mut Cvc5, sm: *mut Cvc5SymbolManager) -> *mut Cvc5InputParser;
+    #[link_name = "\u{1}cvc5_parser_new"]
+    pub fn parser_new(cvc5: *mut Solver, sm: *mut SymbolManager) -> *mut InputParser;
 }
 unsafe extern "C" {
     #[doc = " Delete a cvc5 input parser instance.\n @param parser The input parser instance."]
-    pub fn cvc5_parser_delete(parser: *mut Cvc5InputParser);
+    #[link_name = "\u{1}cvc5_parser_delete"]
+    pub fn parser_delete(parser: *mut InputParser);
 }
 unsafe extern "C" {
     #[doc = " Release all objects managed by the parser.\n\n This will free all memory used by any managed objects allocated by the\n parser.\n\n @note This invalidates all managed objects created by the parser.\n\n @param parser The parser instance."]
-    pub fn cvc5_parser_release(parser: *mut Cvc5InputParser);
+    #[link_name = "\u{1}cvc5_parser_release"]
+    pub fn parser_release(parser: *mut InputParser);
 }
 unsafe extern "C" {
     #[doc = " Get the associated solver instance of a given parser.\n @param parser The parser instance.\n @return The solver."]
-    pub fn cvc5_parser_get_solver(parser: *mut Cvc5InputParser) -> *mut Cvc5;
+    #[link_name = "\u{1}cvc5_parser_get_solver"]
+    pub fn parser_get_solver(parser: *mut InputParser) -> *mut Solver;
 }
 unsafe extern "C" {
     #[doc = " Get the associated symbol manager of a given parser.\n @param parser The parser instance.\n @return The symbol manager."]
-    pub fn cvc5_parser_get_sm(parser: *mut Cvc5InputParser) -> *mut Cvc5SymbolManager;
+    #[link_name = "\u{1}cvc5_parser_get_sm"]
+    pub fn parser_get_sm(parser: *mut InputParser) -> *mut SymbolManager;
 }
 unsafe extern "C" {
     #[doc = " Configure given file as input to a given input parser.\n @param parser The input parser instance.\n @param lang the input language (e.g., #CVC5_INPUT_LANGUAGE_SMT_LIB_2_6)\n @param filename The name of the file to configure."]
-    pub fn cvc5_parser_set_file_input(
-        parser: *mut Cvc5InputParser,
-        lang: Cvc5InputLanguage,
+    #[link_name = "\u{1}cvc5_parser_set_file_input"]
+    pub fn parser_set_file_input(
+        parser: *mut InputParser,
+        lang: InputLanguage,
         filename: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Configure a given concrete input string as the input to a given input parser.\n @param parser The input parser instance.\n @param lang  The input language of the input string.\n @param input The input string.\n @param name  The name to use as input stream name for error messages."]
-    pub fn cvc5_parser_set_str_input(
-        parser: *mut Cvc5InputParser,
-        lang: Cvc5InputLanguage,
+    #[link_name = "\u{1}cvc5_parser_set_str_input"]
+    pub fn parser_set_str_input(
+        parser: *mut InputParser,
+        lang: InputLanguage,
         input: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Configure that we will be feeding strings to a given input parser via\n `cvc5_parser_append_inc_str_input()` below.\n @param parser The input parser instance.\n @param lang  The input language of the input string.\n @param name  The name to use as input stream name for error messages."]
-    pub fn cvc5_parser_set_inc_str_input(
-        parser: *mut Cvc5InputParser,
-        lang: Cvc5InputLanguage,
+    #[link_name = "\u{1}cvc5_parser_set_inc_str_input"]
+    pub fn parser_set_inc_str_input(
+        parser: *mut InputParser,
+        lang: InputLanguage,
         name: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Append string to the input being parsed by this parser. Should be\n called after calling `cvc5_parser_set_inc_str_input()`.\n @param parser The input parser instance.\n @param input  The input string."]
-    pub fn cvc5_parser_append_inc_str_input(
-        parser: *mut Cvc5InputParser,
+    #[link_name = "\u{1}cvc5_parser_append_inc_str_input"]
+    pub fn parser_append_inc_str_input(
+        parser: *mut InputParser,
         input: *const ::std::os::raw::c_char,
     );
 }
 unsafe extern "C" {
     #[doc = " Parse and return the next command. Will initialize the logic to \"ALL\"\n or the forced logic if no logic is set prior to this point and a command\n is read that requires initializing the logic.\n\n @param parser     The input parser instance.\n @param error_msg  Output parameter for the error message in case of a parse\n                   error, NULL if no error occurred.\n @return The parsed command. NULL if no command was read."]
-    pub fn cvc5_parser_next_command(
-        parser: *mut Cvc5InputParser,
+    #[link_name = "\u{1}cvc5_parser_next_command"]
+    pub fn parser_next_command(
+        parser: *mut InputParser,
         error_msg: *mut *const ::std::os::raw::c_char,
-    ) -> Cvc5Command;
+    ) -> Command;
 }
 unsafe extern "C" {
     #[doc = " Parse and return the next term. Requires setting the logic prior\n to this point.\n @param parser     The input parser instance.\n @param error_msg  Output parameter for the error message in case of a parse\n                   error, NULL if no error occurred.\n @return           The parsed term. NULL if no term was read."]
-    pub fn cvc5_parser_next_term(
-        parser: *mut Cvc5InputParser,
+    #[link_name = "\u{1}cvc5_parser_next_term"]
+    pub fn parser_next_term(
+        parser: *mut InputParser,
         error_msg: *mut *const ::std::os::raw::c_char,
-    ) -> Cvc5Term;
+    ) -> Term;
 }
 unsafe extern "C" {
     #[doc = " Is this parser done reading input?\n @param parser The input parser instance.\n @return True if parser is done reading input."]
-    pub fn cvc5_parser_done(parser: *mut Cvc5InputParser) -> bool;
+    #[link_name = "\u{1}cvc5_parser_done"]
+    pub fn parser_done(parser: *mut InputParser) -> bool;
 }

--- a/cvc5-sys/src/lib.rs
+++ b/cvc5-sys/src/lib.rs
@@ -22,24 +22,24 @@
 //! use cvc5_sys::*;
 //!
 //! unsafe {
-//!     let tm = cvc5_term_manager_new();
-//!     let slv = cvc5_new(tm);
+//!     let tm = term_manager_new();
+//!     let slv = new(tm);
 //!
-//!     cvc5_set_logic(slv, c"QF_LIA".as_ptr());
-//!     cvc5_set_option(slv, c"produce-models".as_ptr(), c"true".as_ptr());
+//!     set_logic(slv, c"QF_LIA".as_ptr());
+//!     set_option(slv, c"produce-models".as_ptr(), c"true".as_ptr());
 //!
-//!     let int_sort = cvc5_get_integer_sort(tm);
-//!     let x = cvc5_mk_const(tm, int_sort, c"x".as_ptr());
-//!     let zero = cvc5_mk_integer_int64(tm, 0);
+//!     let int_sort = get_integer_sort(tm);
+//!     let x = mk_const(tm, int_sort, c"x".as_ptr());
+//!     let zero = mk_integer_int64(tm, 0);
 //!
-//!     let gt = cvc5_mk_term(tm, Cvc5Kind::CVC5_KIND_GT, 2, [x, zero].as_ptr());
-//!     cvc5_assert_formula(slv, gt);
+//!     let gt = mk_term(tm, Kind::Gt, 2, [x, zero].as_ptr());
+//!     assert_formula(slv, gt);
 //!
-//!     let result = cvc5_check_sat(slv);
-//!     assert!(cvc5_result_is_sat(result));
+//!     let result = check_sat(slv);
+//!     assert!(result_is_sat(result));
 //!
-//!     cvc5_delete(slv);
-//!     cvc5_term_manager_delete(tm);
+//!     delete(slv);
+//!     term_manager_delete(tm);
 //! }
 //! ```
 

--- a/src/datatype.rs
+++ b/src/datatype.rs
@@ -10,51 +10,51 @@ use crate::{Sort, Term};
 
 /// A declaration for a datatype constructor (before the datatype is resolved).
 pub struct DatatypeConstructorDecl {
-    pub(crate) inner: Cvc5DatatypeConstructorDecl,
+    pub(crate) inner: cvc5_sys::DatatypeConstructorDecl,
 }
 
 impl Clone for DatatypeConstructorDecl {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_dt_cons_decl_copy(self.inner) },
+            inner: unsafe { dt_cons_decl_copy(self.inner) },
         }
     }
 }
 
 impl Drop for DatatypeConstructorDecl {
     fn drop(&mut self) {
-        unsafe { cvc5_dt_cons_decl_release(self.inner) }
+        unsafe { dt_cons_decl_release(self.inner) }
     }
 }
 
 impl DatatypeConstructorDecl {
-    pub(crate) fn from_raw(raw: Cvc5DatatypeConstructorDecl) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::DatatypeConstructorDecl) -> Self {
         Self { inner: raw }
     }
 
     /// Add a selector with the given name and codomain sort.
     pub fn add_selector(&mut self, name: &str, sort: Sort) {
         let c = CString::new(name).unwrap();
-        unsafe { cvc5_dt_cons_decl_add_selector(self.inner, c.as_ptr(), sort.inner) }
+        unsafe { dt_cons_decl_add_selector(self.inner, c.as_ptr(), sort.inner) }
     }
 
     /// Add a selector whose codomain is the datatype itself (self-reference).
     pub fn add_selector_self(&mut self, name: &str) {
         let c = CString::new(name).unwrap();
-        unsafe { cvc5_dt_cons_decl_add_selector_self(self.inner, c.as_ptr()) }
+        unsafe { dt_cons_decl_add_selector_self(self.inner, c.as_ptr()) }
     }
 
     /// Add a selector whose codomain is an unresolved datatype with the given name.
     pub fn add_selector_unresolved(&mut self, name: &str, unres_name: &str) {
         let n = CString::new(name).unwrap();
         let u = CString::new(unres_name).unwrap();
-        unsafe { cvc5_dt_cons_decl_add_selector_unresolved(self.inner, n.as_ptr(), u.as_ptr()) }
+        unsafe { dt_cons_decl_add_selector_unresolved(self.inner, n.as_ptr(), u.as_ptr()) }
     }
 }
 
 impl fmt::Display for DatatypeConstructorDecl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_dt_cons_decl_to_string(self.inner) };
+        let s = unsafe { dt_cons_decl_to_string(self.inner) };
         write!(f, "{}", unsafe {
             std::ffi::CStr::from_ptr(s).to_string_lossy()
         })
@@ -63,14 +63,14 @@ impl fmt::Display for DatatypeConstructorDecl {
 
 impl PartialEq for DatatypeConstructorDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_dt_cons_decl_is_equal(self.inner, other.inner) }
+        unsafe { dt_cons_decl_is_equal(self.inner, other.inner) }
     }
 }
 impl Eq for DatatypeConstructorDecl {}
 
 impl std::hash::Hash for DatatypeConstructorDecl {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_dt_cons_decl_hash(self.inner) }.hash(state);
+        unsafe { dt_cons_decl_hash(self.inner) }.hash(state);
     }
 }
 
@@ -86,57 +86,57 @@ impl fmt::Debug for DatatypeConstructorDecl {
 
 /// A declaration for a datatype (before it is resolved into a sort).
 pub struct DatatypeDecl {
-    pub(crate) inner: Cvc5DatatypeDecl,
+    pub(crate) inner: cvc5_sys::DatatypeDecl,
 }
 
 impl Clone for DatatypeDecl {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_dt_decl_copy(self.inner) },
+            inner: unsafe { dt_decl_copy(self.inner) },
         }
     }
 }
 
 impl Drop for DatatypeDecl {
     fn drop(&mut self) {
-        unsafe { cvc5_dt_decl_release(self.inner) }
+        unsafe { dt_decl_release(self.inner) }
     }
 }
 
 impl DatatypeDecl {
-    pub(crate) fn from_raw(raw: Cvc5DatatypeDecl) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::DatatypeDecl) -> Self {
         Self { inner: raw }
     }
 
     /// Create a copy of this declaration (increments the internal reference count).
     pub fn copy(&self) -> DatatypeDecl {
-        DatatypeDecl::from_raw(unsafe { cvc5_dt_decl_copy(self.inner) })
+        DatatypeDecl::from_raw(unsafe { dt_decl_copy(self.inner) })
     }
 
     /// Add a constructor declaration to this datatype.
     pub fn add_constructor(&mut self, ctor: &DatatypeConstructorDecl) {
-        unsafe { cvc5_dt_decl_add_constructor(self.inner, ctor.inner) }
+        unsafe { dt_decl_add_constructor(self.inner, ctor.inner) }
     }
 
     /// Get the number of constructors in this declaration.
     pub fn num_constructors(&self) -> usize {
-        unsafe { cvc5_dt_decl_get_num_constructors(self.inner) }
+        unsafe { dt_decl_get_num_constructors(self.inner) }
     }
 
     /// Return `true` if this datatype declaration is parametric.
     pub fn is_parametric(&self) -> bool {
-        unsafe { cvc5_dt_decl_is_parametric(self.inner) }
+        unsafe { dt_decl_is_parametric(self.inner) }
     }
 
     /// Return `true` if this datatype declaration has been resolved.
     pub fn is_resolved(&self) -> bool {
-        unsafe { cvc5_dt_decl_is_resolved(self.inner) }
+        unsafe { dt_decl_is_resolved(self.inner) }
     }
 
     /// Get the name of this datatype declaration.
     pub fn name(&self) -> &str {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_dt_decl_get_name(self.inner))
+            std::ffi::CStr::from_ptr(dt_decl_get_name(self.inner))
                 .to_str()
                 .unwrap_or("")
         }
@@ -145,7 +145,7 @@ impl DatatypeDecl {
 
 impl fmt::Display for DatatypeDecl {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_dt_decl_to_string(self.inner) };
+        let s = unsafe { dt_decl_to_string(self.inner) };
         write!(f, "{}", unsafe {
             std::ffi::CStr::from_ptr(s).to_string_lossy()
         })
@@ -154,14 +154,14 @@ impl fmt::Display for DatatypeDecl {
 
 impl PartialEq for DatatypeDecl {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_dt_decl_is_equal(self.inner, other.inner) }
+        unsafe { dt_decl_is_equal(self.inner, other.inner) }
     }
 }
 impl Eq for DatatypeDecl {}
 
 impl std::hash::Hash for DatatypeDecl {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_dt_decl_hash(self.inner) }.hash(state);
+        unsafe { dt_decl_hash(self.inner) }.hash(state);
     }
 }
 
@@ -177,37 +177,37 @@ impl fmt::Debug for DatatypeDecl {
 
 /// A selector of a resolved datatype constructor.
 pub struct DatatypeSelector {
-    pub(crate) inner: Cvc5DatatypeSelector,
+    pub(crate) inner: cvc5_sys::DatatypeSelector,
 }
 
 impl Clone for DatatypeSelector {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_dt_sel_copy(self.inner) },
+            inner: unsafe { dt_sel_copy(self.inner) },
         }
     }
 }
 
 impl Drop for DatatypeSelector {
     fn drop(&mut self) {
-        unsafe { cvc5_dt_sel_release(self.inner) }
+        unsafe { dt_sel_release(self.inner) }
     }
 }
 
 impl DatatypeSelector {
-    pub(crate) fn from_raw(raw: Cvc5DatatypeSelector) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::DatatypeSelector) -> Self {
         Self { inner: raw }
     }
 
     /// Create a copy of this selector (increments the internal reference count).
     pub fn copy(&self) -> DatatypeSelector {
-        DatatypeSelector::from_raw(unsafe { cvc5_dt_sel_copy(self.inner) })
+        DatatypeSelector::from_raw(unsafe { dt_sel_copy(self.inner) })
     }
 
     /// Get the name of this selector.
     pub fn name(&self) -> &str {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_dt_sel_get_name(self.inner))
+            std::ffi::CStr::from_ptr(dt_sel_get_name(self.inner))
                 .to_str()
                 .unwrap_or("")
         }
@@ -215,23 +215,23 @@ impl DatatypeSelector {
 
     /// Get the selector function as a term.
     pub fn term(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_dt_sel_get_term(self.inner) })
+        Term::from_raw(unsafe { dt_sel_get_term(self.inner) })
     }
 
     /// Get the updater function as a term.
     pub fn updater_term(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_dt_sel_get_updater_term(self.inner) })
+        Term::from_raw(unsafe { dt_sel_get_updater_term(self.inner) })
     }
 
     /// Get the codomain (return) sort of this selector.
     pub fn codomain_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_dt_sel_get_codomain_sort(self.inner) })
+        Sort::from_raw(unsafe { dt_sel_get_codomain_sort(self.inner) })
     }
 }
 
 impl fmt::Display for DatatypeSelector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_dt_sel_to_string(self.inner) };
+        let s = unsafe { dt_sel_to_string(self.inner) };
         write!(f, "{}", unsafe {
             std::ffi::CStr::from_ptr(s).to_string_lossy()
         })
@@ -240,14 +240,14 @@ impl fmt::Display for DatatypeSelector {
 
 impl PartialEq for DatatypeSelector {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_dt_sel_is_equal(self.inner, other.inner) }
+        unsafe { dt_sel_is_equal(self.inner, other.inner) }
     }
 }
 impl Eq for DatatypeSelector {}
 
 impl std::hash::Hash for DatatypeSelector {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_dt_sel_hash(self.inner) }.hash(state);
+        unsafe { dt_sel_hash(self.inner) }.hash(state);
     }
 }
 
@@ -263,32 +263,32 @@ impl fmt::Debug for DatatypeSelector {
 
 /// A constructor of a resolved datatype.
 pub struct DatatypeConstructor {
-    pub(crate) inner: Cvc5DatatypeConstructor,
+    pub(crate) inner: cvc5_sys::DatatypeConstructor,
 }
 
 impl Clone for DatatypeConstructor {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_dt_cons_copy(self.inner) },
+            inner: unsafe { dt_cons_copy(self.inner) },
         }
     }
 }
 
 impl Drop for DatatypeConstructor {
     fn drop(&mut self) {
-        unsafe { cvc5_dt_cons_release(self.inner) }
+        unsafe { dt_cons_release(self.inner) }
     }
 }
 
 impl DatatypeConstructor {
-    pub(crate) fn from_raw(raw: Cvc5DatatypeConstructor) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::DatatypeConstructor) -> Self {
         Self { inner: raw }
     }
 
     /// Get the name of this constructor.
     pub fn name(&self) -> &str {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_dt_cons_get_name(self.inner))
+            std::ffi::CStr::from_ptr(dt_cons_get_name(self.inner))
                 .to_str()
                 .unwrap_or("")
         }
@@ -296,41 +296,39 @@ impl DatatypeConstructor {
 
     /// Get the constructor function as a term.
     pub fn term(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_dt_cons_get_term(self.inner) })
+        Term::from_raw(unsafe { dt_cons_get_term(self.inner) })
     }
 
     /// Get the constructor term instantiated for the given parametric datatype sort.
     pub fn instantiated_term(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_dt_cons_get_instantiated_term(self.inner, sort.inner) })
+        Term::from_raw(unsafe { dt_cons_get_instantiated_term(self.inner, sort.inner) })
     }
 
     /// Get the tester (discriminator) function as a term.
     pub fn tester_term(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_dt_cons_get_tester_term(self.inner) })
+        Term::from_raw(unsafe { dt_cons_get_tester_term(self.inner) })
     }
 
     /// Get the number of selectors of this constructor.
     pub fn num_selectors(&self) -> usize {
-        unsafe { cvc5_dt_cons_get_num_selectors(self.inner) }
+        unsafe { dt_cons_get_num_selectors(self.inner) }
     }
 
     /// Get the selector at the given index.
     pub fn selector(&self, index: usize) -> DatatypeSelector {
-        DatatypeSelector::from_raw(unsafe { cvc5_dt_cons_get_selector(self.inner, index) })
+        DatatypeSelector::from_raw(unsafe { dt_cons_get_selector(self.inner, index) })
     }
 
     /// Get a selector by name.
     pub fn selector_by_name(&self, name: &str) -> DatatypeSelector {
         let c = CString::new(name).unwrap();
-        DatatypeSelector::from_raw(unsafe {
-            cvc5_dt_cons_get_selector_by_name(self.inner, c.as_ptr())
-        })
+        DatatypeSelector::from_raw(unsafe { dt_cons_get_selector_by_name(self.inner, c.as_ptr()) })
     }
 }
 
 impl fmt::Display for DatatypeConstructor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_dt_cons_to_string(self.inner) };
+        let s = unsafe { dt_cons_to_string(self.inner) };
         write!(f, "{}", unsafe {
             std::ffi::CStr::from_ptr(s).to_string_lossy()
         })
@@ -339,14 +337,14 @@ impl fmt::Display for DatatypeConstructor {
 
 impl PartialEq for DatatypeConstructor {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_dt_cons_is_equal(self.inner, other.inner) }
+        unsafe { dt_cons_is_equal(self.inner, other.inner) }
     }
 }
 impl Eq for DatatypeConstructor {}
 
 impl std::hash::Hash for DatatypeConstructor {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_dt_cons_hash(self.inner) }.hash(state);
+        unsafe { dt_cons_hash(self.inner) }.hash(state);
     }
 }
 
@@ -365,56 +363,54 @@ impl fmt::Debug for DatatypeConstructor {
 /// Obtained from a sort via [`Sort::datatype`] after the datatype has been
 /// created with [`TermManager::mk_dt_sort`](crate::TermManager::mk_dt_sort).
 pub struct Datatype {
-    pub(crate) inner: Cvc5Datatype,
+    pub(crate) inner: cvc5_sys::Datatype,
 }
 
 impl Clone for Datatype {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_dt_copy(self.inner) },
+            inner: unsafe { dt_copy(self.inner) },
         }
     }
 }
 
 impl Drop for Datatype {
     fn drop(&mut self) {
-        unsafe { cvc5_dt_release(self.inner) }
+        unsafe { dt_release(self.inner) }
     }
 }
 
 impl Datatype {
-    pub(crate) fn from_raw(raw: Cvc5Datatype) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Datatype) -> Self {
         Self { inner: raw }
     }
 
     /// Create a copy of this datatype (increments the internal reference count).
     pub fn copy(&self) -> Datatype {
-        Datatype::from_raw(unsafe { cvc5_dt_copy(self.inner) })
+        Datatype::from_raw(unsafe { dt_copy(self.inner) })
     }
 
     /// Get the constructor at the given index.
     pub fn constructor(&self, index: usize) -> DatatypeConstructor {
-        DatatypeConstructor::from_raw(unsafe { cvc5_dt_get_constructor(self.inner, index) })
+        DatatypeConstructor::from_raw(unsafe { dt_get_constructor(self.inner, index) })
     }
 
     /// Get a constructor by name.
     pub fn constructor_by_name(&self, name: &str) -> DatatypeConstructor {
         let c = CString::new(name).unwrap();
-        DatatypeConstructor::from_raw(unsafe {
-            cvc5_dt_get_constructor_by_name(self.inner, c.as_ptr())
-        })
+        DatatypeConstructor::from_raw(unsafe { dt_get_constructor_by_name(self.inner, c.as_ptr()) })
     }
 
     /// Get a selector by name (searches all constructors).
     pub fn selector(&self, name: &str) -> DatatypeSelector {
         let c = CString::new(name).unwrap();
-        DatatypeSelector::from_raw(unsafe { cvc5_dt_get_selector(self.inner, c.as_ptr()) })
+        DatatypeSelector::from_raw(unsafe { dt_get_selector(self.inner, c.as_ptr()) })
     }
 
     /// Get the name of this datatype.
     pub fn name(&self) -> &str {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_dt_get_name(self.inner))
+            std::ffi::CStr::from_ptr(dt_get_name(self.inner))
                 .to_str()
                 .unwrap_or("")
         }
@@ -422,13 +418,13 @@ impl Datatype {
 
     /// Get the number of constructors.
     pub fn num_constructors(&self) -> usize {
-        unsafe { cvc5_dt_get_num_constructors(self.inner) }
+        unsafe { dt_get_num_constructors(self.inner) }
     }
 
     /// Get the sort parameters of a parametric datatype.
     pub fn parameters(&self) -> Vec<Sort> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_dt_get_parameters(self.inner, &mut size) };
+        let ptr = unsafe { dt_get_parameters(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -436,38 +432,38 @@ impl Datatype {
 
     /// Return `true` if this datatype is parametric.
     pub fn is_parametric(&self) -> bool {
-        unsafe { cvc5_dt_is_parametric(self.inner) }
+        unsafe { dt_is_parametric(self.inner) }
     }
 
     /// Return `true` if this is a codatatype.
     pub fn is_codatatype(&self) -> bool {
-        unsafe { cvc5_dt_is_codatatype(self.inner) }
+        unsafe { dt_is_codatatype(self.inner) }
     }
 
     /// Return `true` if this is a tuple datatype.
     pub fn is_tuple(&self) -> bool {
-        unsafe { cvc5_dt_is_tuple(self.inner) }
+        unsafe { dt_is_tuple(self.inner) }
     }
 
     /// Return `true` if this is a record datatype.
     pub fn is_record(&self) -> bool {
-        unsafe { cvc5_dt_is_record(self.inner) }
+        unsafe { dt_is_record(self.inner) }
     }
 
     /// Return `true` if this datatype is finite.
     pub fn is_finite(&self) -> bool {
-        unsafe { cvc5_dt_is_finite(self.inner) }
+        unsafe { dt_is_finite(self.inner) }
     }
 
     /// Return `true` if this datatype is well-founded.
     pub fn is_well_founded(&self) -> bool {
-        unsafe { cvc5_dt_is_well_founded(self.inner) }
+        unsafe { dt_is_well_founded(self.inner) }
     }
 }
 
 impl fmt::Display for Datatype {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_dt_to_string(self.inner) };
+        let s = unsafe { dt_to_string(self.inner) };
         write!(f, "{}", unsafe {
             std::ffi::CStr::from_ptr(s).to_string_lossy()
         })
@@ -476,14 +472,14 @@ impl fmt::Display for Datatype {
 
 impl PartialEq for Datatype {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_dt_is_equal(self.inner, other.inner) }
+        unsafe { dt_is_equal(self.inner, other.inner) }
     }
 }
 impl Eq for Datatype {}
 
 impl std::hash::Hash for Datatype {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_dt_hash(self.inner) }.hash(state);
+        unsafe { dt_hash(self.inner) }.hash(state);
     }
 }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -7,63 +7,63 @@ use crate::Term;
 ///
 /// Grammars constrain the space of candidate solutions in synthesis queries.
 pub struct Grammar {
-    pub(crate) inner: Cvc5Grammar,
+    pub(crate) inner: cvc5_sys::Grammar,
 }
 
 impl Clone for Grammar {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_grammar_copy(self.inner) },
+            inner: unsafe { grammar_copy(self.inner) },
         }
     }
 }
 
 impl Drop for Grammar {
     fn drop(&mut self) {
-        unsafe { cvc5_grammar_release(self.inner) }
+        unsafe { grammar_release(self.inner) }
     }
 }
 
 impl Grammar {
-    pub(crate) fn from_raw(raw: Cvc5Grammar) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Grammar) -> Self {
         Self { inner: raw }
     }
 
     /// Create a copy of this grammar (increments the internal reference count).
     pub fn copy(&self) -> Grammar {
-        Grammar::from_raw(unsafe { cvc5_grammar_copy(self.inner) })
+        Grammar::from_raw(unsafe { grammar_copy(self.inner) })
     }
 
     /// Check disequality with another grammar.
     pub fn is_disequal(&self, other: &Grammar) -> bool {
-        unsafe { cvc5_grammar_is_disequal(self.inner, other.inner) }
+        unsafe { grammar_is_disequal(self.inner, other.inner) }
     }
 
     /// Add a rule to the given non-terminal symbol.
     pub fn add_rule(&mut self, symbol: Term, rule: Term) {
-        unsafe { cvc5_grammar_add_rule(self.inner, symbol.inner, rule.inner) }
+        unsafe { grammar_add_rule(self.inner, symbol.inner, rule.inner) }
     }
 
     /// Add rules to the given non-terminal symbol.
     pub fn add_rules(&mut self, symbol: Term, rules: &[Term]) {
-        let raw: Vec<Cvc5Term> = rules.iter().map(|t| t.inner).collect();
-        unsafe { cvc5_grammar_add_rules(self.inner, symbol.inner, raw.len(), raw.as_ptr()) }
+        let raw: Vec<cvc5_sys::Term> = rules.iter().map(|t| t.inner).collect();
+        unsafe { grammar_add_rules(self.inner, symbol.inner, raw.len(), raw.as_ptr()) }
     }
 
     /// Allow the symbol to be an arbitrary constant.
     pub fn add_any_constant(&mut self, symbol: Term) {
-        unsafe { cvc5_grammar_add_any_constant(self.inner, symbol.inner) }
+        unsafe { grammar_add_any_constant(self.inner, symbol.inner) }
     }
 
     /// Allow the symbol to be any input variable.
     pub fn add_any_variable(&mut self, symbol: Term) {
-        unsafe { cvc5_grammar_add_any_variable(self.inner, symbol.inner) }
+        unsafe { grammar_add_any_variable(self.inner, symbol.inner) }
     }
 }
 
 impl fmt::Display for Grammar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_grammar_to_string(self.inner) };
+        let s = unsafe { grammar_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
         write!(f, "{}", cs.to_string_lossy())
     }
@@ -71,7 +71,7 @@ impl fmt::Display for Grammar {
 
 impl PartialEq for Grammar {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_grammar_is_equal(self.inner, other.inner) }
+        unsafe { grammar_is_equal(self.inner, other.inner) }
     }
 }
 
@@ -79,7 +79,7 @@ impl Eq for Grammar {}
 
 impl std::hash::Hash for Grammar {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_grammar_hash(self.inner) }.hash(state);
+        unsafe { grammar_hash(self.inner) }.hash(state);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,20 +41,20 @@ mod synth_result;
 mod term;
 mod term_manager;
 
-pub use cvc5_sys::Cvc5BlockModelsMode as BlockModelsMode;
-pub use cvc5_sys::Cvc5FindSynthTarget as FindSynthTarget;
-pub use cvc5_sys::Cvc5Kind as Kind;
-pub use cvc5_sys::Cvc5LearnedLitType as LearnedLitType;
-pub use cvc5_sys::Cvc5OptionInfo;
-pub use cvc5_sys::Cvc5Plugin;
-pub use cvc5_sys::Cvc5ProofComponent as ProofComponent;
-pub use cvc5_sys::Cvc5ProofFormat as ProofFormat;
-pub use cvc5_sys::Cvc5ProofRewriteRule as ProofRewriteRule;
-pub use cvc5_sys::Cvc5ProofRule as ProofRule;
-pub use cvc5_sys::Cvc5RoundingMode as RoundingMode;
-pub use cvc5_sys::Cvc5SkolemId as SkolemId;
-pub use cvc5_sys::Cvc5SortKind as SortKind;
-pub use cvc5_sys::Cvc5UnknownExplanation as UnknownExplanation;
+pub use cvc5_sys::BlockModelsMode;
+pub use cvc5_sys::FindSynthTarget;
+pub use cvc5_sys::Kind;
+pub use cvc5_sys::LearnedLitType;
+pub use cvc5_sys::OptionInfo;
+pub use cvc5_sys::Plugin;
+pub use cvc5_sys::ProofComponent;
+pub use cvc5_sys::ProofFormat;
+pub use cvc5_sys::ProofRewriteRule;
+pub use cvc5_sys::ProofRule;
+pub use cvc5_sys::RoundingMode;
+pub use cvc5_sys::SkolemId;
+pub use cvc5_sys::SortKind;
+pub use cvc5_sys::UnknownExplanation;
 
 pub use datatype::{
     Datatype, DatatypeConstructor, DatatypeConstructorDecl, DatatypeDecl, DatatypeSelector,
@@ -71,7 +71,7 @@ pub use term::Term;
 pub use term_manager::TermManager;
 
 #[cfg(feature = "parser")]
-pub use cvc5_sys::Cvc5InputLanguage as InputLanguage;
+pub use cvc5_sys::InputLanguage;
 #[cfg(feature = "parser")]
 pub use parser::{Command, InputParser, SymbolManager};
 
@@ -79,7 +79,7 @@ pub use parser::{Command, InputParser, SymbolManager};
 #[cfg(feature = "parser")]
 pub fn input_language_to_string(lang: InputLanguage) -> String {
     unsafe {
-        std::ffi::CStr::from_ptr(cvc5_sys::cvc5_modes_input_language_to_string(lang))
+        std::ffi::CStr::from_ptr(cvc5_sys::modes_input_language_to_string(lang))
             .to_string_lossy()
             .into_owned()
     }
@@ -104,49 +104,49 @@ macro_rules! enum_to_string_fn {
 
 enum_to_string_fn!(
     /// Get a string representation of a [`Kind`].
-    kind_to_string, Kind, cvc5_sys::cvc5_kind_to_string
+    kind_to_string, Kind, cvc5_sys::kind_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`SortKind`].
-    sort_kind_to_string, SortKind, cvc5_sys::cvc5_sort_kind_to_string
+    sort_kind_to_string, SortKind, cvc5_sys::sort_kind_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`ProofRule`].
-    proof_rule_to_string, ProofRule, cvc5_sys::cvc5_proof_rule_to_string
+    proof_rule_to_string, ProofRule, cvc5_sys::proof_rule_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`ProofRewriteRule`].
-    proof_rewrite_rule_to_string, ProofRewriteRule, cvc5_sys::cvc5_proof_rewrite_rule_to_string
+    proof_rewrite_rule_to_string, ProofRewriteRule, cvc5_sys::proof_rewrite_rule_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`RoundingMode`].
-    rounding_mode_to_string, RoundingMode, cvc5_sys::cvc5_rm_to_string
+    rounding_mode_to_string, RoundingMode, cvc5_sys::rm_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`SkolemId`].
-    skolem_id_to_string, SkolemId, cvc5_sys::cvc5_skolem_id_to_string
+    skolem_id_to_string, SkolemId, cvc5_sys::skolem_id_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of an [`UnknownExplanation`].
-    unknown_explanation_to_string, UnknownExplanation, cvc5_sys::cvc5_unknown_explanation_to_string
+    unknown_explanation_to_string, UnknownExplanation, cvc5_sys::unknown_explanation_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`BlockModelsMode`].
-    block_models_mode_to_string, BlockModelsMode, cvc5_sys::cvc5_modes_block_models_mode_to_string
+    block_models_mode_to_string, BlockModelsMode, cvc5_sys::modes_block_models_mode_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`LearnedLitType`].
-    learned_lit_type_to_string, LearnedLitType, cvc5_sys::cvc5_modes_learned_lit_type_to_string
+    learned_lit_type_to_string, LearnedLitType, cvc5_sys::modes_learned_lit_type_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`ProofComponent`].
-    proof_component_to_string, ProofComponent, cvc5_sys::cvc5_modes_proof_component_to_string
+    proof_component_to_string, ProofComponent, cvc5_sys::modes_proof_component_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`ProofFormat`].
-    proof_format_to_string, ProofFormat, cvc5_sys::cvc5_modes_proof_format_to_string
+    proof_format_to_string, ProofFormat, cvc5_sys::modes_proof_format_to_string
 );
 enum_to_string_fn!(
     /// Get a string representation of a [`FindSynthTarget`].
-    find_synth_target_to_string, FindSynthTarget, cvc5_sys::cvc5_modes_find_synth_target_to_string
+    find_synth_target_to_string, FindSynthTarget, cvc5_sys::modes_find_synth_target_to_string
 );

--- a/src/op.rs
+++ b/src/op.rs
@@ -8,62 +8,62 @@ use crate::Term;
 /// Operators are used to create terms with parameterized kinds, such as
 /// bit-vector extract with specific indices.
 pub struct Op {
-    pub(crate) inner: Cvc5Op,
+    pub(crate) inner: cvc5_sys::Op,
 }
 
 impl Clone for Op {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_op_copy(self.inner) },
+            inner: unsafe { op_copy(self.inner) },
         }
     }
 }
 
 impl Drop for Op {
     fn drop(&mut self) {
-        unsafe { cvc5_op_release(self.inner) }
+        unsafe { op_release(self.inner) }
     }
 }
 
 impl Op {
-    pub(crate) fn from_raw(raw: Cvc5Op) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Op) -> Self {
         Self { inner: raw }
     }
 
     /// Get the kind of this operator.
-    pub fn kind(&self) -> Cvc5Kind {
-        unsafe { cvc5_op_get_kind(self.inner) }
+    pub fn kind(&self) -> cvc5_sys::Kind {
+        unsafe { op_get_kind(self.inner) }
     }
 
     /// Create a copy of this operator (increments the internal reference count).
     pub fn copy(&self) -> Op {
-        Op::from_raw(unsafe { cvc5_op_copy(self.inner) })
+        Op::from_raw(unsafe { op_copy(self.inner) })
     }
 
     /// Check disequality with another operator.
     pub fn is_disequal(&self, other: &Op) -> bool {
-        unsafe { cvc5_op_is_disequal(self.inner, other.inner) }
+        unsafe { op_is_disequal(self.inner, other.inner) }
     }
 
     /// Return `true` if this operator is indexed.
     pub fn is_indexed(&self) -> bool {
-        unsafe { cvc5_op_is_indexed(self.inner) }
+        unsafe { op_is_indexed(self.inner) }
     }
 
     /// Get the number of indices of this operator.
     pub fn num_indices(&self) -> usize {
-        unsafe { cvc5_op_get_num_indices(self.inner) }
+        unsafe { op_get_num_indices(self.inner) }
     }
 
     /// Get the index at position `i` as a term.
     pub fn index(&self, i: usize) -> Term {
-        Term::from_raw(unsafe { cvc5_op_get_index(self.inner, i) })
+        Term::from_raw(unsafe { op_get_index(self.inner, i) })
     }
 }
 
 impl fmt::Display for Op {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_op_to_string(self.inner) };
+        let s = unsafe { op_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
         write!(f, "{}", cs.to_string_lossy())
     }
@@ -77,7 +77,7 @@ impl fmt::Debug for Op {
 
 impl PartialEq for Op {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_op_is_equal(self.inner, other.inner) }
+        unsafe { op_is_equal(self.inner, other.inner) }
     }
 }
 
@@ -85,6 +85,6 @@ impl Eq for Op {}
 
 impl std::hash::Hash for Op {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_op_hash(self.inner) }.hash(state);
+        unsafe { op_hash(self.inner) }.hash(state);
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@
 //! }
 //! ```
 
-use cvc5_sys::Cvc5InputLanguage as InputLanguage;
+use cvc5_sys::InputLanguage;
 use cvc5_sys::parser::*;
 use std::cell::RefCell;
 use std::ffi::CString;
@@ -52,7 +52,7 @@ use crate::{Solver, Sort, Term, TermManager};
 /// cheaply cloned and shared while still allowing mutation through `&self`.
 #[derive(Clone)]
 pub struct SymbolManager {
-    inner: Rc<RefCell<*mut Cvc5SymbolManager>>,
+    inner: Rc<RefCell<*mut cvc5_sys::parser::SymbolManager>>,
     tm: TermManager,
 }
 
@@ -61,12 +61,12 @@ impl SymbolManager {
     pub fn new(tm: impl std::borrow::Borrow<TermManager>) -> Self {
         let tm = tm.borrow().clone();
         Self {
-            inner: Rc::new(RefCell::new(unsafe { cvc5_symbol_manager_new(tm.ptr()) })),
+            inner: Rc::new(RefCell::new(unsafe { symbol_manager_new(tm.ptr()) })),
             tm,
         }
     }
 
-    pub(crate) fn ptr(&self) -> *mut Cvc5SymbolManager {
+    pub(crate) fn ptr(&self) -> *mut cvc5_sys::parser::SymbolManager {
         *self.inner.borrow()
     }
 
@@ -77,7 +77,7 @@ impl SymbolManager {
 
     /// Return whether the logic has been set.
     pub fn is_logic_set(&self) -> bool {
-        unsafe { cvc5_sm_is_logic_set(self.ptr()) }
+        unsafe { sm_is_logic_set(self.ptr()) }
     }
 
     /// Get the logic string (e.g. `"QF_LIA"`).
@@ -87,7 +87,7 @@ impl SymbolManager {
     /// The underlying C API asserts that the logic has been set.
     pub fn get_logic(&self) -> &str {
         unsafe {
-            let s = cvc5_sm_get_logic(self.ptr());
+            let s = sm_get_logic(self.ptr());
             std::ffi::CStr::from_ptr(s).to_str().unwrap_or("")
         }
     }
@@ -97,7 +97,7 @@ impl SymbolManager {
     /// These are the sorts printed as part of a `get-model` response.
     pub fn get_declared_sorts(&self) -> Vec<Sort> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_sm_get_declared_sorts(self.ptr(), &mut size) };
+        let ptr = unsafe { sm_get_declared_sorts(self.ptr(), &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -108,7 +108,7 @@ impl SymbolManager {
     /// These are the terms printed in a `get-model` response.
     pub fn get_declared_terms(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_sm_get_declared_terms(self.ptr(), &mut size) };
+        let ptr = unsafe { sm_get_declared_terms(self.ptr(), &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -119,9 +119,9 @@ impl SymbolManager {
     /// Returns a list of `(term, name)` pairs.
     pub fn get_named_terms(&self) -> Vec<(Term, String)> {
         let mut size = 0usize;
-        let mut terms: *mut cvc5_sys::Cvc5Term = std::ptr::null_mut();
+        let mut terms: *mut cvc5_sys::Term = std::ptr::null_mut();
         let mut names: *mut *const std::os::raw::c_char = std::ptr::null_mut();
-        unsafe { cvc5_sm_get_named_terms(self.ptr(), &mut size, &mut terms, &mut names) };
+        unsafe { sm_get_named_terms(self.ptr(), &mut size, &mut terms, &mut names) };
         (0..size)
             .map(|i| unsafe {
                 let t = Term::from_raw(*terms.add(i));
@@ -137,7 +137,7 @@ impl SymbolManager {
 impl Drop for SymbolManager {
     fn drop(&mut self) {
         if Rc::strong_count(&self.inner) == 1 {
-            unsafe { cvc5_symbol_manager_delete(self.ptr()) }
+            unsafe { symbol_manager_delete(self.ptr()) }
         }
     }
 }
@@ -151,11 +151,11 @@ impl Drop for SymbolManager {
 /// Commands are produced by [`InputParser::next_command`] and can be executed
 /// on a solver and symbol manager via [`Command::invoke`].
 pub struct Command {
-    pub(crate) inner: Cvc5Command,
+    pub(crate) inner: cvc5_sys::parser::Command,
 }
 
 impl Command {
-    pub(crate) fn from_raw(raw: Cvc5Command) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::parser::Command) -> Self {
         Self { inner: raw }
     }
 
@@ -170,7 +170,7 @@ impl Command {
     /// model output, etc.).
     pub fn invoke(&self, solver: &mut Solver, sm: &mut SymbolManager) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_cmd_invoke(self.inner, solver.inner, sm.ptr()))
+            std::ffi::CStr::from_ptr(cmd_invoke(self.inner, solver.inner, sm.ptr()))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -179,7 +179,7 @@ impl Command {
     /// Get the name of this command (e.g. `"assert"`, `"check-sat"`).
     pub fn name(&self) -> &str {
         unsafe {
-            let s = cvc5_cmd_get_name(self.inner);
+            let s = cmd_get_name(self.inner);
             std::ffi::CStr::from_ptr(s).to_str().unwrap_or("")
         }
     }
@@ -187,7 +187,7 @@ impl Command {
 
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_cmd_to_string(self.inner) };
+        let s = unsafe { cmd_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
         write!(f, "{}", cs.to_string_lossy())
     }
@@ -215,7 +215,7 @@ impl fmt::Debug for Command {
 /// [`next_term`](InputParser::next_term) in a loop until
 /// [`done`](InputParser::done) returns `true`.
 pub struct InputParser {
-    inner: *mut Cvc5InputParser,
+    inner: *mut cvc5_sys::parser::InputParser,
     /// This field is public for reclaiming the ownership of the solver
     pub solver: Solver,
     sm: SymbolManager,
@@ -236,7 +236,7 @@ impl InputParser {
             .unwrap_or_else(|| SymbolManager::new(&solver.tm));
         let sm_ptr = sm.ptr();
         Self {
-            inner: unsafe { cvc5_parser_new(solver.inner, sm_ptr) },
+            inner: unsafe { parser_new(solver.inner, sm_ptr) },
             solver,
             sm,
         }
@@ -258,11 +258,11 @@ impl InputParser {
     /// Configure a file as the input source.
     ///
     /// - `lang` — the input language (e.g.
-    ///   [`SmtLib26`](cvc5_sys::Cvc5InputLanguage::SmtLib26)).
+    ///   [`SmtLib26`](sys::cvc5_sys::InputLanguage::SmtLib26)).
     /// - `filename` — path to the file.
     pub fn set_file_input(&mut self, lang: InputLanguage, filename: &str) {
         let f = CString::new(filename).unwrap();
-        unsafe { cvc5_parser_set_file_input(self.inner, lang, f.as_ptr()) }
+        unsafe { parser_set_file_input(self.inner, lang, f.as_ptr()) }
     }
 
     /// Configure a concrete string as the input source.
@@ -273,7 +273,7 @@ impl InputParser {
     pub fn set_str_input(&mut self, lang: InputLanguage, input: &str, name: &str) {
         let i = CString::new(input).unwrap();
         let n = CString::new(name).unwrap();
-        unsafe { cvc5_parser_set_str_input(self.inner, lang, i.as_ptr(), n.as_ptr()) }
+        unsafe { parser_set_str_input(self.inner, lang, i.as_ptr(), n.as_ptr()) }
     }
 
     /// Configure incremental string input mode.
@@ -285,7 +285,7 @@ impl InputParser {
     /// - `name` — a name used in error messages.
     pub fn set_inc_str_input(&mut self, lang: InputLanguage, name: &str) {
         let n = CString::new(name).unwrap();
-        unsafe { cvc5_parser_set_inc_str_input(self.inner, lang, n.as_ptr()) }
+        unsafe { parser_set_inc_str_input(self.inner, lang, n.as_ptr()) }
     }
 
     /// Append a string to the incremental input stream.
@@ -293,7 +293,7 @@ impl InputParser {
     /// Must be called after [`set_inc_str_input`](InputParser::set_inc_str_input).
     pub fn append_inc_str_input(&mut self, input: &str) {
         let i = CString::new(input).unwrap();
-        unsafe { cvc5_parser_append_inc_str_input(self.inner, i.as_ptr()) }
+        unsafe { parser_append_inc_str_input(self.inner, i.as_ptr()) }
     }
 
     /// Parse and return the next command.
@@ -307,7 +307,7 @@ impl InputParser {
     /// initialize the logic to `"ALL"`.
     pub fn next_command(&mut self) -> Result<Option<Command>, String> {
         let mut error_msg: *const std::os::raw::c_char = std::ptr::null();
-        let cmd = unsafe { cvc5_parser_next_command(self.inner, &mut error_msg) };
+        let cmd = unsafe { parser_next_command(self.inner, &mut error_msg) };
         if !error_msg.is_null() {
             let msg = unsafe { std::ffi::CStr::from_ptr(error_msg) }
                 .to_string_lossy()
@@ -331,7 +331,7 @@ impl InputParser {
     /// The logic must be set before calling this method.
     pub fn next_term(&mut self) -> Result<Option<Term>, String> {
         let mut error_msg: *const std::os::raw::c_char = std::ptr::null();
-        let term = unsafe { cvc5_parser_next_term(self.inner, &mut error_msg) };
+        let term = unsafe { parser_next_term(self.inner, &mut error_msg) };
         if !error_msg.is_null() {
             let msg = unsafe { std::ffi::CStr::from_ptr(error_msg) }
                 .to_string_lossy()
@@ -347,12 +347,12 @@ impl InputParser {
 
     /// Return `true` if the parser has finished reading all input.
     pub fn done(&self) -> bool {
-        unsafe { cvc5_parser_done(self.inner) }
+        unsafe { parser_done(self.inner) }
     }
 }
 
 impl Drop for InputParser {
     fn drop(&mut self) {
-        unsafe { cvc5_parser_delete(self.inner) }
+        unsafe { parser_delete(self.inner) }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -258,7 +258,7 @@ impl InputParser {
     /// Configure a file as the input source.
     ///
     /// - `lang` — the input language (e.g.
-    ///   [`SmtLib26`](sys::cvc5_sys::InputLanguage::SmtLib26)).
+    ///   [`SmtLib26`](cvc5_sys::InputLanguage::SmtLib26)).
     /// - `filename` — path to the file.
     pub fn set_file_input(&mut self, lang: InputLanguage, filename: &str) {
         let f = CString::new(filename).unwrap();

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -8,57 +8,57 @@ use crate::Term;
 /// Proofs are produced when the solver is configured with
 /// `set_option("produce-proofs", "true")` and a query returns unsat.
 pub struct Proof {
-    pub(crate) inner: Cvc5Proof,
+    pub(crate) inner: cvc5_sys::Proof,
 }
 
 impl Clone for Proof {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_proof_copy(self.inner) },
+            inner: unsafe { proof_copy(self.inner) },
         }
     }
 }
 
 impl Drop for Proof {
     fn drop(&mut self) {
-        unsafe { cvc5_proof_release(self.inner) }
+        unsafe { proof_release(self.inner) }
     }
 }
 
 impl Proof {
-    pub(crate) fn from_raw(raw: Cvc5Proof) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Proof) -> Self {
         Self { inner: raw }
     }
 
     /// Get the proof rule used at the root of this proof node.
-    pub fn rule(&self) -> Cvc5ProofRule {
-        unsafe { cvc5_proof_get_rule(self.inner) }
+    pub fn rule(&self) -> cvc5_sys::ProofRule {
+        unsafe { proof_get_rule(self.inner) }
     }
 
     /// Create a copy of this proof (increments the internal reference count).
     pub fn copy(&self) -> Proof {
-        Proof::from_raw(unsafe { cvc5_proof_copy(self.inner) })
+        Proof::from_raw(unsafe { proof_copy(self.inner) })
     }
 
     /// Check disequality with another proof.
     pub fn is_disequal(&self, other: &Proof) -> bool {
-        unsafe { cvc5_proof_is_disequal(self.inner, other.inner) }
+        unsafe { proof_is_disequal(self.inner, other.inner) }
     }
 
     /// Get the rewrite rule used at the root of this proof node.
-    pub fn rewrite_rule(&self) -> Cvc5ProofRewriteRule {
-        unsafe { cvc5_proof_get_rewrite_rule(self.inner) }
+    pub fn rewrite_rule(&self) -> cvc5_sys::ProofRewriteRule {
+        unsafe { proof_get_rewrite_rule(self.inner) }
     }
 
     /// Get the conclusion (result) of this proof node as a term.
     pub fn result(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_proof_get_result(self.inner) })
+        Term::from_raw(unsafe { proof_get_result(self.inner) })
     }
 
     /// Get the child proof nodes.
     pub fn children(&self) -> Vec<Proof> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_proof_get_children(self.inner, &mut size) };
+        let ptr = unsafe { proof_get_children(self.inner, &mut size) };
         (0..size)
             .map(|i| Proof::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -67,7 +67,7 @@ impl Proof {
     /// Get the arguments of this proof node as terms.
     pub fn arguments(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_proof_get_arguments(self.inner, &mut size) };
+        let ptr = unsafe { proof_get_arguments(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -76,7 +76,7 @@ impl Proof {
 
 impl PartialEq for Proof {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_proof_is_equal(self.inner, other.inner) }
+        unsafe { proof_is_equal(self.inner, other.inner) }
     }
 }
 
@@ -84,7 +84,7 @@ impl Eq for Proof {}
 
 impl std::hash::Hash for Proof {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_proof_hash(self.inner) }.hash(state);
+        unsafe { proof_hash(self.inner) }.hash(state);
     }
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -3,67 +3,67 @@ use std::fmt;
 
 /// The result of a satisfiability check.
 pub struct Result {
-    pub(crate) inner: Cvc5Result,
+    pub(crate) inner: cvc5_sys::Result,
 }
 
 impl Clone for Result {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_result_copy(self.inner) },
+            inner: unsafe { result_copy(self.inner) },
         }
     }
 }
 
 impl Drop for Result {
     fn drop(&mut self) {
-        unsafe { cvc5_result_release(self.inner) }
+        unsafe { result_release(self.inner) }
     }
 }
 
 impl Result {
-    pub(crate) fn from_raw(raw: Cvc5Result) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Result) -> Self {
         Self { inner: raw }
     }
 
     /// Return `true` if this is a null (uninitialized) result.
     pub fn is_null(&self) -> bool {
-        unsafe { cvc5_result_is_null(self.inner) }
+        unsafe { result_is_null(self.inner) }
     }
 
     /// Create a copy of this result (increments the internal reference count).
     pub fn copy(&self) -> Result {
-        Result::from_raw(unsafe { cvc5_result_copy(self.inner) })
+        Result::from_raw(unsafe { result_copy(self.inner) })
     }
 
     /// Check disequality with another result.
     pub fn is_disequal(&self, other: &Result) -> bool {
-        unsafe { cvc5_result_is_disequal(self.inner, other.inner) }
+        unsafe { result_is_disequal(self.inner, other.inner) }
     }
 
     /// Return `true` if the query was satisfiable.
     pub fn is_sat(&self) -> bool {
-        unsafe { cvc5_result_is_sat(self.inner) }
+        unsafe { result_is_sat(self.inner) }
     }
 
     /// Return `true` if the query was unsatisfiable.
     pub fn is_unsat(&self) -> bool {
-        unsafe { cvc5_result_is_unsat(self.inner) }
+        unsafe { result_is_unsat(self.inner) }
     }
 
     /// Return `true` if the result is unknown.
     pub fn is_unknown(&self) -> bool {
-        unsafe { cvc5_result_is_unknown(self.inner) }
+        unsafe { result_is_unknown(self.inner) }
     }
 
     /// Get the explanation for an unknown result.
-    pub fn unknown_explanation(&self) -> Cvc5UnknownExplanation {
-        unsafe { cvc5_result_get_unknown_explanation(self.inner) }
+    pub fn unknown_explanation(&self) -> cvc5_sys::UnknownExplanation {
+        unsafe { result_get_unknown_explanation(self.inner) }
     }
 }
 
 impl fmt::Display for Result {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_result_to_string(self.inner) };
+        let s = unsafe { result_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
         write!(f, "{}", cs.to_string_lossy())
     }
@@ -77,7 +77,7 @@ impl fmt::Debug for Result {
 
 impl PartialEq for Result {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_result_is_equal(self.inner, other.inner) }
+        unsafe { result_is_equal(self.inner, other.inner) }
     }
 }
 
@@ -85,6 +85,6 @@ impl Eq for Result {}
 
 impl std::hash::Hash for Result {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_result_hash(self.inner) }.hash(state);
+        unsafe { result_hash(self.inner) }.hash(state);
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -12,7 +12,7 @@ use crate::{
 /// Holds a clone of the [`TermManager`] that created it, ensuring the
 /// underlying C term manager outlives this solver.
 pub struct Solver {
-    pub(crate) inner: *mut Cvc5,
+    pub(crate) inner: *mut cvc5_sys::Solver,
     pub(crate) tm: TermManager,
 }
 
@@ -21,7 +21,7 @@ impl Solver {
     pub fn new(tm: impl Borrow<TermManager>) -> Self {
         let tm = tm.borrow().clone();
         Self {
-            inner: unsafe { cvc5_new(tm.ptr()) },
+            inner: unsafe { new(tm.ptr()) },
             tm,
         }
     }
@@ -36,18 +36,18 @@ impl Solver {
     /// Set the logic for this solver (e.g. , ).
     pub fn set_logic(&mut self, logic: &str) {
         let c = CString::new(logic).unwrap();
-        unsafe { cvc5_set_logic(self.inner, c.as_ptr()) }
+        unsafe { set_logic(self.inner, c.as_ptr()) }
     }
 
     /// Return `true` if the logic has been set.
     pub fn is_logic_set(&self) -> bool {
-        unsafe { cvc5_is_logic_set(self.inner) }
+        unsafe { is_logic_set(self.inner) }
     }
 
     /// Get the currently set logic as a string.
     pub fn get_logic(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_get_logic(self.inner))
+            std::ffi::CStr::from_ptr(get_logic(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -57,14 +57,14 @@ impl Solver {
     pub fn set_option(&mut self, option: &str, value: &str) {
         let o = CString::new(option).unwrap();
         let v = CString::new(value).unwrap();
-        unsafe { cvc5_set_option(self.inner, o.as_ptr(), v.as_ptr()) }
+        unsafe { set_option(self.inner, o.as_ptr(), v.as_ptr()) }
     }
 
     /// Get the current value of a solver option.
     pub fn get_option(&self, option: &str) -> String {
         let o = CString::new(option).unwrap();
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_get_option(self.inner, o.as_ptr()))
+            std::ffi::CStr::from_ptr(get_option(self.inner, o.as_ptr()))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -73,7 +73,7 @@ impl Solver {
     /// Get the list of all option names.
     pub fn get_option_names(&self) -> Vec<String> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_option_names(self.inner, &mut size) };
+        let ptr = unsafe { get_option_names(self.inner, &mut size) };
         (0..size)
             .map(|i| unsafe {
                 std::ffi::CStr::from_ptr(*ptr.add(i))
@@ -87,14 +87,14 @@ impl Solver {
     pub fn set_info(&mut self, keyword: &str, value: &str) {
         let k = CString::new(keyword).unwrap();
         let v = CString::new(value).unwrap();
-        unsafe { cvc5_set_info(self.inner, k.as_ptr(), v.as_ptr()) }
+        unsafe { set_info(self.inner, k.as_ptr(), v.as_ptr()) }
     }
 
     /// Get solver information (SMT-LIB `get-info`).
     pub fn get_info(&self, flag: &str) -> String {
         let f = CString::new(flag).unwrap();
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_get_info(self.inner, f.as_ptr()))
+            std::ffi::CStr::from_ptr(get_info(self.inner, f.as_ptr()))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -104,24 +104,24 @@ impl Solver {
 
     /// Assert a formula to the solver.
     pub fn assert_formula(&mut self, term: Term) {
-        unsafe { cvc5_assert_formula(self.inner, term.inner) }
+        unsafe { assert_formula(self.inner, term.inner) }
     }
 
     /// Check satisfiability of the current assertions.
     pub fn check_sat(&mut self) -> Result {
-        Result::from_raw(unsafe { cvc5_check_sat(self.inner) })
+        Result::from_raw(unsafe { check_sat(self.inner) })
     }
 
     /// Check satisfiability under the given assumptions.
     pub fn check_sat_assuming(&mut self, assumptions: &[Term]) -> Result {
-        let raw: Vec<Cvc5Term> = assumptions.iter().map(|t| t.inner).collect();
-        Result::from_raw(unsafe { cvc5_check_sat_assuming(self.inner, raw.len(), raw.as_ptr()) })
+        let raw: Vec<cvc5_sys::Term> = assumptions.iter().map(|t| t.inner).collect();
+        Result::from_raw(unsafe { check_sat_assuming(self.inner, raw.len(), raw.as_ptr()) })
     }
 
     /// Get the list of asserted formulas.
     pub fn get_assertions(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_assertions(self.inner, &mut size) };
+        let ptr = unsafe { get_assertions(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -131,21 +131,21 @@ impl Solver {
 
     /// Simplify a term. If `apply_subs` is true, apply learned substitutions.
     pub fn simplify(&self, term: Term, apply_subs: bool) -> Term {
-        Term::from_raw(unsafe { cvc5_simplify(self.inner, term.inner, apply_subs) })
+        Term::from_raw(unsafe { simplify(self.inner, term.inner, apply_subs) })
     }
 
     // ── Model queries ──────────────────────────────────────────────
 
     /// Get the value of a term in the current model.
     pub fn get_value(&self, term: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_get_value(self.inner, term.inner) })
+        Term::from_raw(unsafe { get_value(self.inner, term.inner) })
     }
 
     /// Get the values of multiple terms in the current model.
     pub fn get_values(&self, terms: &[Term]) -> Vec<Term> {
-        let raw: Vec<Cvc5Term> = terms.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
         let mut rsize = 0usize;
-        let ptr = unsafe { cvc5_get_values(self.inner, raw.len(), raw.as_ptr(), &mut rsize) };
+        let ptr = unsafe { get_values(self.inner, raw.len(), raw.as_ptr(), &mut rsize) };
         (0..rsize)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -154,7 +154,7 @@ impl Solver {
     /// Get the domain elements of an uninterpreted sort in the current model.
     pub fn get_model_domain_elements(&self, sort: Sort) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_model_domain_elements(self.inner, sort.inner, &mut size) };
+        let ptr = unsafe { get_model_domain_elements(self.inner, sort.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -162,15 +162,15 @@ impl Solver {
 
     /// Return `true` if the given variable is a model core symbol.
     pub fn is_model_core_symbol(&self, v: Term) -> bool {
-        unsafe { cvc5_is_model_core_symbol(self.inner, v.inner) }
+        unsafe { is_model_core_symbol(self.inner, v.inner) }
     }
 
     /// Get a string representation of the current model.
     pub fn get_model(&self, sorts: &[Sort], consts: &[Term]) -> String {
-        let rs: Vec<Cvc5Sort> = sorts.iter().map(|s| s.inner).collect();
-        let rt: Vec<Cvc5Term> = consts.iter().map(|t| t.inner).collect();
+        let rs: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
+        let rt: Vec<cvc5_sys::Term> = consts.iter().map(|t| t.inner).collect();
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_get_model(
+            std::ffi::CStr::from_ptr(get_model(
                 self.inner,
                 rs.len(),
                 rs.as_ptr(),
@@ -183,14 +183,14 @@ impl Solver {
     }
 
     /// Block the current model using the given mode.
-    pub fn block_model(&mut self, mode: Cvc5BlockModelsMode) {
-        unsafe { cvc5_block_model(self.inner, mode) }
+    pub fn block_model(&mut self, mode: cvc5_sys::BlockModelsMode) {
+        unsafe { block_model(self.inner, mode) }
     }
 
     /// Block the current model values for the given terms.
     pub fn block_model_values(&mut self, terms: &[Term]) {
-        let raw: Vec<Cvc5Term> = terms.iter().map(|t| t.inner).collect();
-        unsafe { cvc5_block_model_values(self.inner, raw.len(), raw.as_ptr()) }
+        let raw: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
+        unsafe { block_model_values(self.inner, raw.len(), raw.as_ptr()) }
     }
 
     // ── Declarations ───────────────────────────────────────────────
@@ -198,9 +198,9 @@ impl Solver {
     /// Declare a function (SMT-LIB `declare-fun`).
     pub fn declare_fun(&mut self, name: &str, domain: &[Sort], codomain: Sort) -> Term {
         let c = CString::new(name).unwrap();
-        let raw: Vec<Cvc5Sort> = domain.iter().map(|s| s.inner).collect();
+        let raw: Vec<cvc5_sys::Sort> = domain.iter().map(|s| s.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_declare_fun(
+            declare_fun(
                 self.inner,
                 c.as_ptr(),
                 raw.len(),
@@ -214,14 +214,14 @@ impl Solver {
     /// Declare an uninterpreted sort (SMT-LIB `declare-sort`).
     pub fn declare_sort(&mut self, name: &str, arity: u32) -> Sort {
         let c = CString::new(name).unwrap();
-        Sort::from_raw(unsafe { cvc5_declare_sort(self.inner, c.as_ptr(), arity, true) })
+        Sort::from_raw(unsafe { declare_sort(self.inner, c.as_ptr(), arity, true) })
     }
 
     /// Declare a datatype from constructor declarations.
     pub fn declare_dt(&mut self, symbol: &str, ctors: &[DatatypeConstructorDecl]) -> Sort {
         let c = CString::new(symbol).unwrap();
-        let raw: Vec<Cvc5DatatypeConstructorDecl> = ctors.iter().map(|d| d.inner).collect();
-        Sort::from_raw(unsafe { cvc5_declare_dt(self.inner, c.as_ptr(), raw.len(), raw.as_ptr()) })
+        let raw: Vec<cvc5_sys::DatatypeConstructorDecl> = ctors.iter().map(|d| d.inner).collect();
+        Sort::from_raw(unsafe { declare_dt(self.inner, c.as_ptr(), raw.len(), raw.as_ptr()) })
     }
 
     // ── Definitions ────────────────────────────────────────────────
@@ -236,9 +236,9 @@ impl Solver {
         global: bool,
     ) -> Term {
         let c = CString::new(symbol).unwrap();
-        let raw: Vec<Cvc5Term> = vars.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_define_fun(
+            define_fun(
                 self.inner,
                 c.as_ptr(),
                 raw.len(),
@@ -260,9 +260,9 @@ impl Solver {
         global: bool,
     ) -> Term {
         let c = CString::new(symbol).unwrap();
-        let raw: Vec<Cvc5Term> = vars.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_define_fun_rec(
+            define_fun_rec(
                 self.inner,
                 c.as_ptr(),
                 raw.len(),
@@ -282,9 +282,9 @@ impl Solver {
         term: Term,
         global: bool,
     ) -> Term {
-        let raw: Vec<Cvc5Term> = vars.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_define_fun_rec_from_const(
+            define_fun_rec_from_const(
                 self.inner,
                 fun.inner,
                 raw.len(),
@@ -299,15 +299,15 @@ impl Solver {
 
     /// Push `n` assertion scope levels.
     pub fn push(&mut self, n: u32) {
-        unsafe { cvc5_push(self.inner, n) }
+        unsafe { push(self.inner, n) }
     }
     /// Pop `n` assertion scope levels.
     pub fn pop(&mut self, n: u32) {
-        unsafe { cvc5_pop(self.inner, n) }
+        unsafe { pop(self.inner, n) }
     }
     /// Remove all assertions and reset the scope.
     pub fn reset_assertions(&mut self) {
-        unsafe { cvc5_reset_assertions(self.inner) }
+        unsafe { reset_assertions(self.inner) }
     }
 
     // ── Unsat core / assumptions ───────────────────────────────────
@@ -315,7 +315,7 @@ impl Solver {
     /// Get the unsat core (subset of assertions that are unsatisfiable).
     pub fn get_unsat_core(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_unsat_core(self.inner, &mut size) };
+        let ptr = unsafe { get_unsat_core(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -324,7 +324,7 @@ impl Solver {
     /// Get the lemmas used in the unsat core.
     pub fn get_unsat_core_lemmas(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_unsat_core_lemmas(self.inner, &mut size) };
+        let ptr = unsafe { get_unsat_core_lemmas(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -333,7 +333,7 @@ impl Solver {
     /// Get the unsat assumptions (subset of assumptions from `check_sat_assuming`).
     pub fn get_unsat_assumptions(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_unsat_assumptions(self.inner, &mut size) };
+        let ptr = unsafe { get_unsat_assumptions(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -342,9 +342,9 @@ impl Solver {
     // ── Proofs ─────────────────────────────────────────────────────
 
     /// Get the proof of unsatisfiability.
-    pub fn get_proof(&self, c: Cvc5ProofComponent) -> Vec<Proof> {
+    pub fn get_proof(&self, c: cvc5_sys::ProofComponent) -> Vec<Proof> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_proof(self.inner, c, &mut size) };
+        let ptr = unsafe { get_proof(self.inner, c, &mut size) };
         (0..size)
             .map(|i| Proof::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -354,15 +354,15 @@ impl Solver {
     pub fn proof_to_string(
         &self,
         proof: Proof,
-        format: Cvc5ProofFormat,
+        format: cvc5_sys::ProofFormat,
         assertions: &[Term],
         names: &[&str],
     ) -> String {
-        let rt: Vec<Cvc5Term> = assertions.iter().map(|t| t.inner).collect();
+        let rt: Vec<cvc5_sys::Term> = assertions.iter().map(|t| t.inner).collect();
         let cnames: Vec<CString> = names.iter().map(|n| CString::new(*n).unwrap()).collect();
         let mut ptrs: Vec<*const std::ffi::c_char> = cnames.iter().map(|c| c.as_ptr()).collect();
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_proof_to_string(
+            std::ffi::CStr::from_ptr(proof_to_string(
                 self.inner,
                 proof.inner,
                 format,
@@ -378,9 +378,9 @@ impl Solver {
     // ── Learned literals / difficulty ──────────────────────────────
 
     /// Get the learned literals of the given type.
-    pub fn get_learned_literals(&self, lit_type: Cvc5LearnedLitType) -> Vec<Term> {
+    pub fn get_learned_literals(&self, lit_type: cvc5_sys::LearnedLitType) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_learned_literals(self.inner, lit_type, &mut size) };
+        let ptr = unsafe { get_learned_literals(self.inner, lit_type, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -389,9 +389,9 @@ impl Solver {
     /// Get the difficulty of each assertion as `(inputs, values)` pairs.
     pub fn get_difficulty(&self) -> (Vec<Term>, Vec<Term>) {
         let mut size = 0usize;
-        let mut inputs: *mut Cvc5Term = std::ptr::null_mut();
-        let mut values: *mut Cvc5Term = std::ptr::null_mut();
-        unsafe { cvc5_get_difficulty(self.inner, &mut size, &mut inputs, &mut values) };
+        let mut inputs: *mut cvc5_sys::Term = std::ptr::null_mut();
+        let mut values: *mut cvc5_sys::Term = std::ptr::null_mut();
+        unsafe { get_difficulty(self.inner, &mut size, &mut inputs, &mut values) };
         let i = (0..size)
             .map(|j| Term::from_raw(unsafe { *inputs.add(j) }))
             .collect();
@@ -405,9 +405,9 @@ impl Solver {
 
     /// Get a timeout core: a minimal subset of assertions causing a timeout.
     pub fn get_timeout_core(&mut self) -> (Result, Vec<Term>) {
-        let mut result: Cvc5Result = std::ptr::null_mut();
+        let mut result: cvc5_sys::Result = std::ptr::null_mut();
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_timeout_core(self.inner, &mut result, &mut size) };
+        let ptr = unsafe { get_timeout_core(self.inner, &mut result, &mut size) };
         let terms = (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect();
@@ -416,17 +416,11 @@ impl Solver {
 
     /// Get a timeout core under the given assumptions.
     pub fn get_timeout_core_assuming(&mut self, assumptions: &[Term]) -> (Result, Vec<Term>) {
-        let raw: Vec<Cvc5Term> = assumptions.iter().map(|t| t.inner).collect();
-        let mut result: Cvc5Result = std::ptr::null_mut();
+        let raw: Vec<cvc5_sys::Term> = assumptions.iter().map(|t| t.inner).collect();
+        let mut result: cvc5_sys::Result = std::ptr::null_mut();
         let mut rsize = 0usize;
         let ptr = unsafe {
-            cvc5_get_timeout_core_assuming(
-                self.inner,
-                raw.len(),
-                raw.as_ptr(),
-                &mut result,
-                &mut rsize,
-            )
+            get_timeout_core_assuming(self.inner, raw.len(), raw.as_ptr(), &mut result, &mut rsize)
         };
         let terms = (0..rsize)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
@@ -438,29 +432,29 @@ impl Solver {
 
     /// Perform quantifier elimination on the given formula.
     pub fn get_quantifier_elimination(&self, q: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_get_quantifier_elimination(self.inner, q.inner) })
+        Term::from_raw(unsafe { get_quantifier_elimination(self.inner, q.inner) })
     }
 
     /// Perform partial quantifier elimination, returning a single disjunct.
     pub fn get_quantifier_elimination_disjunct(&self, q: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_get_quantifier_elimination_disjunct(self.inner, q.inner) })
+        Term::from_raw(unsafe { get_quantifier_elimination_disjunct(self.inner, q.inner) })
     }
 
     // ── Separation logic ───────────────────────────────────────────
 
     /// Declare the heap sorts for separation logic.
     pub fn declare_sep_heap(&mut self, loc: Sort, data: Sort) {
-        unsafe { cvc5_declare_sep_heap(self.inner, loc.inner, data.inner) }
+        unsafe { declare_sep_heap(self.inner, loc.inner, data.inner) }
     }
 
     /// Get the separation logic heap term.
     pub fn get_value_sep_heap(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_get_value_sep_heap(self.inner) })
+        Term::from_raw(unsafe { get_value_sep_heap(self.inner) })
     }
 
     /// Get the separation logic nil term.
     pub fn get_value_sep_nil(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_get_value_sep_nil(self.inner) })
+        Term::from_raw(unsafe { get_value_sep_nil(self.inner) })
     }
 
     // ── Pools ──────────────────────────────────────────────────────
@@ -468,9 +462,9 @@ impl Solver {
     /// Declare a term pool with the given initial values.
     pub fn declare_pool(&mut self, symbol: &str, sort: Sort, init_value: &[Term]) -> Term {
         let c = CString::new(symbol).unwrap();
-        let raw: Vec<Cvc5Term> = init_value.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = init_value.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_declare_pool(self.inner, c.as_ptr(), sort.inner, raw.len(), raw.as_ptr())
+            declare_pool(self.inner, c.as_ptr(), sort.inner, raw.len(), raw.as_ptr())
         })
     }
 
@@ -480,7 +474,7 @@ impl Solver {
     ///
     /// Returns `None` if no interpolant exists.
     pub fn get_interpolant(&self, conj: Term) -> Option<Term> {
-        let raw = unsafe { cvc5_get_interpolant(self.inner, conj.inner) };
+        let raw = unsafe { get_interpolant(self.inner, conj.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -488,8 +482,7 @@ impl Solver {
     ///
     /// Returns `None` if no interpolant exists.
     pub fn get_interpolant_with_grammar(&self, conj: Term, grammar: &Grammar) -> Option<Term> {
-        let raw =
-            unsafe { cvc5_get_interpolant_with_grammar(self.inner, conj.inner, grammar.inner) };
+        let raw = unsafe { get_interpolant_with_grammar(self.inner, conj.inner, grammar.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -497,7 +490,7 @@ impl Solver {
     ///
     /// Returns `None` if no further interpolant can be found.
     pub fn get_interpolant_next(&self) -> Option<Term> {
-        let raw = unsafe { cvc5_get_interpolant_next(self.inner) };
+        let raw = unsafe { get_interpolant_next(self.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -507,7 +500,7 @@ impl Solver {
     ///
     /// Returns `None` if no abduct can be found.
     pub fn get_abduct(&self, conj: Term) -> Option<Term> {
-        let raw = unsafe { cvc5_get_abduct(self.inner, conj.inner) };
+        let raw = unsafe { get_abduct(self.inner, conj.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -515,7 +508,7 @@ impl Solver {
     ///
     /// Returns `None` if no abduct can be found.
     pub fn get_abduct_with_grammar(&self, conj: Term, grammar: &Grammar) -> Option<Term> {
-        let raw = unsafe { cvc5_get_abduct_with_grammar(self.inner, conj.inner, grammar.inner) };
+        let raw = unsafe { get_abduct_with_grammar(self.inner, conj.inner, grammar.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -523,7 +516,7 @@ impl Solver {
     ///
     /// Returns `None` if no further abduct can be found.
     pub fn get_abduct_next(&self) -> Option<Term> {
-        let raw = unsafe { cvc5_get_abduct_next(self.inner) };
+        let raw = unsafe { get_abduct_next(self.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -532,7 +525,7 @@ impl Solver {
     /// Get a string representation of all quantifier instantiations.
     pub fn get_instantiations(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_get_instantiations(self.inner))
+            std::ffi::CStr::from_ptr(get_instantiations(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -543,24 +536,24 @@ impl Solver {
     /// Declare a SyGuS variable.
     pub fn declare_sygus_var(&mut self, symbol: &str, sort: Sort) -> Term {
         let c = CString::new(symbol).unwrap();
-        Term::from_raw(unsafe { cvc5_declare_sygus_var(self.inner, c.as_ptr(), sort.inner) })
+        Term::from_raw(unsafe { declare_sygus_var(self.inner, c.as_ptr(), sort.inner) })
     }
 
     /// Create a SyGuS grammar from bound variables and non-terminal symbols.
     pub fn mk_grammar(&self, bound_vars: &[Term], symbols: &[Term]) -> Grammar {
-        let bv: Vec<Cvc5Term> = bound_vars.iter().map(|t| t.inner).collect();
-        let sy: Vec<Cvc5Term> = symbols.iter().map(|t| t.inner).collect();
+        let bv: Vec<cvc5_sys::Term> = bound_vars.iter().map(|t| t.inner).collect();
+        let sy: Vec<cvc5_sys::Term> = symbols.iter().map(|t| t.inner).collect();
         Grammar::from_raw(unsafe {
-            cvc5_mk_grammar(self.inner, bv.len(), bv.as_ptr(), sy.len(), sy.as_ptr())
+            mk_grammar(self.inner, bv.len(), bv.as_ptr(), sy.len(), sy.as_ptr())
         })
     }
 
     /// Declare a function to synthesize (SyGuS `synth-fun`).
     pub fn synth_fun(&mut self, symbol: &str, bound_vars: &[Term], sort: Sort) -> Term {
         let c = CString::new(symbol).unwrap();
-        let raw: Vec<Cvc5Term> = bound_vars.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = bound_vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_synth_fun(self.inner, c.as_ptr(), raw.len(), raw.as_ptr(), sort.inner)
+            synth_fun(self.inner, c.as_ptr(), raw.len(), raw.as_ptr(), sort.inner)
         })
     }
 
@@ -573,9 +566,9 @@ impl Solver {
         grammar: &Grammar,
     ) -> Term {
         let c = CString::new(symbol).unwrap();
-        let raw: Vec<Cvc5Term> = bound_vars.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = bound_vars.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_synth_fun_with_grammar(
+            synth_fun_with_grammar(
                 self.inner,
                 c.as_ptr(),
                 raw.len(),
@@ -588,13 +581,13 @@ impl Solver {
 
     /// Add a SyGuS constraint.
     pub fn add_sygus_constraint(&mut self, term: Term) {
-        unsafe { cvc5_add_sygus_constraint(self.inner, term.inner) }
+        unsafe { add_sygus_constraint(self.inner, term.inner) }
     }
 
     /// Get the list of SyGuS constraints.
     pub fn get_sygus_constraints(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_sygus_constraints(self.inner, &mut size) };
+        let ptr = unsafe { get_sygus_constraints(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -602,13 +595,13 @@ impl Solver {
 
     /// Add a SyGuS assumption.
     pub fn add_sygus_assume(&mut self, term: Term) {
-        unsafe { cvc5_add_sygus_assume(self.inner, term.inner) }
+        unsafe { add_sygus_assume(self.inner, term.inner) }
     }
 
     /// Get the list of SyGuS assumptions.
     pub fn get_sygus_assumptions(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_get_sygus_assumptions(self.inner, &mut size) };
+        let ptr = unsafe { get_sygus_assumptions(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -617,29 +610,29 @@ impl Solver {
     /// Add a SyGuS invariant constraint.
     pub fn add_sygus_inv_constraint(&mut self, inv: Term, pre: Term, trans: Term, post: Term) {
         unsafe {
-            cvc5_add_sygus_inv_constraint(self.inner, inv.inner, pre.inner, trans.inner, post.inner)
+            add_sygus_inv_constraint(self.inner, inv.inner, pre.inner, trans.inner, post.inner)
         }
     }
 
     /// Check for a synthesis solution.
     pub fn check_synth(&mut self) -> SynthResult {
-        SynthResult::from_raw(unsafe { cvc5_check_synth(self.inner) })
+        SynthResult::from_raw(unsafe { check_synth(self.inner) })
     }
 
     /// Get the next synthesis solution.
     pub fn check_synth_next(&mut self) -> SynthResult {
-        SynthResult::from_raw(unsafe { cvc5_check_synth_next(self.inner) })
+        SynthResult::from_raw(unsafe { check_synth_next(self.inner) })
     }
 
     /// Get the synthesis solution for a given function-to-synthesize term.
     pub fn get_synth_solution(&self, term: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_get_synth_solution(self.inner, term.inner) })
+        Term::from_raw(unsafe { get_synth_solution(self.inner, term.inner) })
     }
 
     /// Get synthesis solutions for multiple function-to-synthesize terms.
     pub fn get_synth_solutions(&self, terms: &[Term]) -> Vec<Term> {
-        let raw: Vec<Cvc5Term> = terms.iter().map(|t| t.inner).collect();
-        let ptr = unsafe { cvc5_get_synth_solutions(self.inner, raw.len(), raw.as_ptr()) };
+        let raw: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
+        let ptr = unsafe { get_synth_solutions(self.inner, raw.len(), raw.as_ptr()) };
         (0..terms.len())
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -648,8 +641,8 @@ impl Solver {
     /// Find a synthesis target of the given type.
     ///
     /// Returns `None` if the call failed.
-    pub fn find_synth(&self, target: Cvc5FindSynthTarget) -> Option<Term> {
-        let raw = unsafe { cvc5_find_synth(self.inner, target) };
+    pub fn find_synth(&self, target: cvc5_sys::FindSynthTarget) -> Option<Term> {
+        let raw = unsafe { find_synth(self.inner, target) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -658,10 +651,10 @@ impl Solver {
     /// Returns `None` if the call failed.
     pub fn find_synth_with_grammar(
         &self,
-        target: Cvc5FindSynthTarget,
+        target: cvc5_sys::FindSynthTarget,
         grammar: &Grammar,
     ) -> Option<Term> {
-        let raw = unsafe { cvc5_find_synth_with_grammar(self.inner, target, grammar.inner) };
+        let raw = unsafe { find_synth_with_grammar(self.inner, target, grammar.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -669,7 +662,7 @@ impl Solver {
     ///
     /// Returns `None` if the call failed.
     pub fn find_synth_next(&self) -> Option<Term> {
-        let raw = unsafe { cvc5_find_synth_next(self.inner) };
+        let raw = unsafe { find_synth_next(self.inner) };
         (!raw.is_null()).then(|| Term::from_raw(raw))
     }
 
@@ -683,16 +676,17 @@ impl Solver {
         terms: &[Term],
         global: bool,
     ) {
-        let rf: Vec<Cvc5Term> = funs.iter().map(|t| t.inner).collect();
+        let rf: Vec<cvc5_sys::Term> = funs.iter().map(|t| t.inner).collect();
         let mut nvars: Vec<usize> = vars.iter().map(|v| v.len()).collect();
-        let raw_vars: Vec<Vec<Cvc5Term>> = vars
+        let raw_vars: Vec<Vec<cvc5_sys::Term>> = vars
             .iter()
             .map(|v| v.iter().map(|t| t.inner).collect())
             .collect();
-        let mut var_ptrs: Vec<*const Cvc5Term> = raw_vars.iter().map(|v| v.as_ptr()).collect();
-        let rt: Vec<Cvc5Term> = terms.iter().map(|t| t.inner).collect();
+        let mut var_ptrs: Vec<*const cvc5_sys::Term> =
+            raw_vars.iter().map(|v| v.as_ptr()).collect();
+        let rt: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
         unsafe {
-            cvc5_define_funs_rec(
+            define_funs_rec(
                 self.inner,
                 rf.len(),
                 rf.as_ptr(),
@@ -710,18 +704,18 @@ impl Solver {
     pub fn get_output(&self, tag: &str, filename: &str) {
         let t = CString::new(tag).unwrap();
         let f = CString::new(filename).unwrap();
-        unsafe { cvc5_get_output(self.inner, t.as_ptr(), f.as_ptr()) }
+        unsafe { get_output(self.inner, t.as_ptr(), f.as_ptr()) }
     }
 
     /// Close a previously opened output file.
     pub fn close_output(&self, filename: &str) {
         let f = CString::new(filename).unwrap();
-        unsafe { cvc5_close_output(self.inner, f.as_ptr()) }
+        unsafe { close_output(self.inner, f.as_ptr()) }
     }
 
     /// Print statistics to the given file descriptor (async-signal-safe).
     pub fn print_stats_safe(&self, fd: i32) {
-        unsafe { cvc5_print_stats_safe(self.inner, fd) }
+        unsafe { print_stats_safe(self.inner, fd) }
     }
 
     // ── Statistics / output ────────────────────────────────────────
@@ -729,26 +723,26 @@ impl Solver {
     /// Return `true` if the given output tag is enabled.
     pub fn is_output_on(&self, tag: &str) -> bool {
         let c = CString::new(tag).unwrap();
-        unsafe { cvc5_is_output_on(self.inner, c.as_ptr()) }
+        unsafe { is_output_on(self.inner, c.as_ptr()) }
     }
 
     /// Get the solver statistics.
     pub fn get_statistics(&self) -> Statistics {
-        Statistics::from_raw(unsafe { cvc5_get_statistics(self.inner) })
+        Statistics::from_raw(unsafe { get_statistics(self.inner) })
     }
 
     /// Get detailed information about a solver option.
-    pub fn get_option_info(&self, option: &str) -> Cvc5OptionInfo {
+    pub fn get_option_info(&self, option: &str) -> cvc5_sys::OptionInfo {
         let c = CString::new(option).unwrap();
-        let mut info: Cvc5OptionInfo = unsafe { std::mem::zeroed() };
-        unsafe { cvc5_get_option_info(self.inner, c.as_ptr(), &mut info) };
+        let mut info: cvc5_sys::OptionInfo = unsafe { std::mem::zeroed() };
+        unsafe { get_option_info(self.inner, c.as_ptr(), &mut info) };
         info
     }
 
     /// Convert option info to a human-readable string.
-    pub fn option_info_to_string(info: &Cvc5OptionInfo) -> String {
+    pub fn option_info_to_string(info: &cvc5_sys::OptionInfo) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_option_info_to_string(info))
+            std::ffi::CStr::from_ptr(option_info_to_string(info))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -757,14 +751,14 @@ impl Solver {
     // ── Plugin ─────────────────────────────────────────────────────
 
     /// Add a plugin to the solver.
-    pub fn add_plugin(&mut self, plugin: &mut Cvc5Plugin) {
-        unsafe { cvc5_add_plugin(self.inner, plugin) }
+    pub fn add_plugin(&mut self, plugin: &mut cvc5_sys::Plugin) {
+        unsafe { add_plugin(self.inner, plugin) }
     }
 
     /// Get the cvc5 version string.
     pub fn version(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_get_version(self.inner))
+            std::ffi::CStr::from_ptr(get_version(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -773,6 +767,6 @@ impl Solver {
 
 impl Drop for Solver {
     fn drop(&mut self) {
-        unsafe { cvc5_delete(self.inner) }
+        unsafe { delete(self.inner) }
     }
 }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -8,185 +8,185 @@ use crate::Datatype;
 /// Sorts represent types in the SMT solver — Boolean, Integer, Real,
 /// BitVector, Array, Datatype, etc.
 pub struct Sort {
-    pub(crate) inner: Cvc5Sort,
+    pub(crate) inner: cvc5_sys::Sort,
 }
 
 impl Clone for Sort {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_sort_copy(self.inner) },
+            inner: unsafe { sort_copy(self.inner) },
         }
     }
 }
 
 impl Drop for Sort {
     fn drop(&mut self) {
-        unsafe { cvc5_sort_release(self.inner) }
+        unsafe { sort_release(self.inner) }
     }
 }
 
 impl Sort {
-    pub(crate) fn from_raw(raw: Cvc5Sort) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Sort) -> Self {
         Self { inner: raw }
     }
 
     /// Get the kind of this sort.
-    pub fn kind(&self) -> Cvc5SortKind {
-        unsafe { cvc5_sort_get_kind(self.inner) }
+    pub fn kind(&self) -> cvc5_sys::SortKind {
+        unsafe { sort_get_kind(self.inner) }
     }
 
     /// Create a copy of this sort (increments the internal reference count).
     pub fn copy(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_copy(self.inner) })
+        Sort::from_raw(unsafe { sort_copy(self.inner) })
     }
 
     /// Check disequality with another sort.
     pub fn is_disequal(&self, other: &Sort) -> bool {
-        unsafe { cvc5_sort_is_disequal(self.inner, other.inner) }
+        unsafe { sort_is_disequal(self.inner, other.inner) }
     }
 
     /// Return `true` if this sort has a symbol (name).
     pub fn has_symbol(&self) -> bool {
-        unsafe { cvc5_sort_has_symbol(self.inner) }
+        unsafe { sort_has_symbol(self.inner) }
     }
 
     /// Get the symbol (name) of this sort.
     pub fn symbol(&self) -> &str {
         unsafe {
-            let s = cvc5_sort_get_symbol(self.inner);
+            let s = sort_get_symbol(self.inner);
             std::ffi::CStr::from_ptr(s).to_str().unwrap_or("")
         }
     }
 
     /// Return `true` if this is the Boolean sort.
     pub fn is_boolean(&self) -> bool {
-        unsafe { cvc5_sort_is_boolean(self.inner) }
+        unsafe { sort_is_boolean(self.inner) }
     }
     /// Return `true` if this is the Integer sort.
     pub fn is_integer(&self) -> bool {
-        unsafe { cvc5_sort_is_integer(self.inner) }
+        unsafe { sort_is_integer(self.inner) }
     }
     /// Return `true` if this is the Real sort.
     pub fn is_real(&self) -> bool {
-        unsafe { cvc5_sort_is_real(self.inner) }
+        unsafe { sort_is_real(self.inner) }
     }
     /// Return `true` if this is the String sort.
     pub fn is_string(&self) -> bool {
-        unsafe { cvc5_sort_is_string(self.inner) }
+        unsafe { sort_is_string(self.inner) }
     }
     /// Return `true` if this is the RegExp sort.
     pub fn is_regexp(&self) -> bool {
-        unsafe { cvc5_sort_is_regexp(self.inner) }
+        unsafe { sort_is_regexp(self.inner) }
     }
     /// Return `true` if this is the rounding mode sort.
     pub fn is_rm(&self) -> bool {
-        unsafe { cvc5_sort_is_rm(self.inner) }
+        unsafe { sort_is_rm(self.inner) }
     }
     /// Return `true` if this is a bit-vector sort.
     pub fn is_bv(&self) -> bool {
-        unsafe { cvc5_sort_is_bv(self.inner) }
+        unsafe { sort_is_bv(self.inner) }
     }
     /// Return `true` if this is a floating-point sort.
     pub fn is_fp(&self) -> bool {
-        unsafe { cvc5_sort_is_fp(self.inner) }
+        unsafe { sort_is_fp(self.inner) }
     }
     /// Return `true` if this is a datatype sort.
     pub fn is_dt(&self) -> bool {
-        unsafe { cvc5_sort_is_dt(self.inner) }
+        unsafe { sort_is_dt(self.inner) }
     }
     /// Return `true` if this is a datatype constructor sort.
     pub fn is_dt_constructor(&self) -> bool {
-        unsafe { cvc5_sort_is_dt_constructor(self.inner) }
+        unsafe { sort_is_dt_constructor(self.inner) }
     }
     /// Return `true` if this is a datatype selector sort.
     pub fn is_dt_selector(&self) -> bool {
-        unsafe { cvc5_sort_is_dt_selector(self.inner) }
+        unsafe { sort_is_dt_selector(self.inner) }
     }
     /// Return `true` if this is a datatype tester sort.
     pub fn is_dt_tester(&self) -> bool {
-        unsafe { cvc5_sort_is_dt_tester(self.inner) }
+        unsafe { sort_is_dt_tester(self.inner) }
     }
     /// Return `true` if this is a datatype updater sort.
     pub fn is_dt_updater(&self) -> bool {
-        unsafe { cvc5_sort_is_dt_updater(self.inner) }
+        unsafe { sort_is_dt_updater(self.inner) }
     }
     /// Return `true` if this is a function sort.
     pub fn is_fun(&self) -> bool {
-        unsafe { cvc5_sort_is_fun(self.inner) }
+        unsafe { sort_is_fun(self.inner) }
     }
     /// Return `true` if this is a predicate sort.
     pub fn is_predicate(&self) -> bool {
-        unsafe { cvc5_sort_is_predicate(self.inner) }
+        unsafe { sort_is_predicate(self.inner) }
     }
     /// Return `true` if this is a tuple sort.
     pub fn is_tuple(&self) -> bool {
-        unsafe { cvc5_sort_is_tuple(self.inner) }
+        unsafe { sort_is_tuple(self.inner) }
     }
     /// Return `true` if this is a nullable sort.
     pub fn is_nullable(&self) -> bool {
-        unsafe { cvc5_sort_is_nullable(self.inner) }
+        unsafe { sort_is_nullable(self.inner) }
     }
     /// Return `true` if this is a record sort.
     pub fn is_record(&self) -> bool {
-        unsafe { cvc5_sort_is_record(self.inner) }
+        unsafe { sort_is_record(self.inner) }
     }
     /// Return `true` if this is an array sort.
     pub fn is_array(&self) -> bool {
-        unsafe { cvc5_sort_is_array(self.inner) }
+        unsafe { sort_is_array(self.inner) }
     }
     /// Return `true` if this is a finite field sort.
     pub fn is_ff(&self) -> bool {
-        unsafe { cvc5_sort_is_ff(self.inner) }
+        unsafe { sort_is_ff(self.inner) }
     }
     /// Return `true` if this is a set sort.
     pub fn is_set(&self) -> bool {
-        unsafe { cvc5_sort_is_set(self.inner) }
+        unsafe { sort_is_set(self.inner) }
     }
     /// Return `true` if this is a bag sort.
     pub fn is_bag(&self) -> bool {
-        unsafe { cvc5_sort_is_bag(self.inner) }
+        unsafe { sort_is_bag(self.inner) }
     }
     /// Return `true` if this is a sequence sort.
     pub fn is_sequence(&self) -> bool {
-        unsafe { cvc5_sort_is_sequence(self.inner) }
+        unsafe { sort_is_sequence(self.inner) }
     }
     /// Return `true` if this is an abstract sort.
     pub fn is_abstract(&self) -> bool {
-        unsafe { cvc5_sort_is_abstract(self.inner) }
+        unsafe { sort_is_abstract(self.inner) }
     }
     /// Return `true` if this is an uninterpreted sort.
     pub fn is_uninterpreted_sort(&self) -> bool {
-        unsafe { cvc5_sort_is_uninterpreted_sort(self.inner) }
+        unsafe { sort_is_uninterpreted_sort(self.inner) }
     }
     /// Return `true` if this is an uninterpreted sort constructor.
     pub fn is_uninterpreted_sort_constructor(&self) -> bool {
-        unsafe { cvc5_sort_is_uninterpreted_sort_constructor(self.inner) }
+        unsafe { sort_is_uninterpreted_sort_constructor(self.inner) }
     }
     /// Return `true` if this sort is an instantiated (parametric) sort.
     pub fn is_instantiated(&self) -> bool {
-        unsafe { cvc5_sort_is_instantiated(self.inner) }
+        unsafe { sort_is_instantiated(self.inner) }
     }
 
     /// Get the associated uninterpreted sort constructor of an instantiated sort.
     pub fn uninterpreted_sort_constructor(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_get_uninterpreted_sort_constructor(self.inner) })
+        Sort::from_raw(unsafe { sort_get_uninterpreted_sort_constructor(self.inner) })
     }
 
     /// Get the datatype associated with a datatype sort.
     pub fn datatype(&self) -> Datatype {
-        Datatype::from_raw(unsafe { cvc5_sort_get_datatype(self.inner) })
+        Datatype::from_raw(unsafe { sort_get_datatype(self.inner) })
     }
 
     /// Instantiate a parametric sort with the given sort parameters.
     pub fn instantiate(&self, params: &[Sort]) -> Sort {
-        let raw: Vec<Cvc5Sort> = params.iter().map(|s| s.inner).collect();
-        Sort::from_raw(unsafe { cvc5_sort_instantiate(self.inner, raw.len(), raw.as_ptr()) })
+        let raw: Vec<cvc5_sys::Sort> = params.iter().map(|s| s.inner).collect();
+        Sort::from_raw(unsafe { sort_instantiate(self.inner, raw.len(), raw.as_ptr()) })
     }
 
     /// Get the sort parameters of an instantiated sort.
     pub fn instantiated_parameters(&self) -> Vec<Sort> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_sort_get_instantiated_parameters(self.inner, &mut size) };
+        let ptr = unsafe { sort_get_instantiated_parameters(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -194,15 +194,15 @@ impl Sort {
 
     /// Substitute `s` with `replacement` in this sort.
     pub fn substitute(&self, s: Sort, replacement: Sort) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_substitute(self.inner, s.inner, replacement.inner) })
+        Sort::from_raw(unsafe { sort_substitute(self.inner, s.inner, replacement.inner) })
     }
 
     /// Simultaneously substitute `sorts` with `replacements` in this sort.
     pub fn substitute_sorts(&self, sorts: &[Sort], replacements: &[Sort]) -> Sort {
-        let s: Vec<Cvc5Sort> = sorts.iter().map(|s| s.inner).collect();
-        let r: Vec<Cvc5Sort> = replacements.iter().map(|s| s.inner).collect();
+        let s: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
+        let r: Vec<cvc5_sys::Sort> = replacements.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe {
-            cvc5_sort_substitute_sorts(self.inner, s.len(), s.as_ptr(), r.as_ptr())
+            sort_substitute_sorts(self.inner, s.len(), s.as_ptr(), r.as_ptr())
         })
     }
 
@@ -210,13 +210,13 @@ impl Sort {
 
     /// Get the arity of a datatype constructor sort.
     pub fn dt_constructor_arity(&self) -> usize {
-        unsafe { cvc5_sort_dt_constructor_get_arity(self.inner) }
+        unsafe { sort_dt_constructor_get_arity(self.inner) }
     }
 
     /// Get the domain sorts of a datatype constructor sort.
     pub fn dt_constructor_domain(&self) -> Vec<Sort> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_sort_dt_constructor_get_domain(self.inner, &mut size) };
+        let ptr = unsafe { sort_dt_constructor_get_domain(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -224,44 +224,44 @@ impl Sort {
 
     /// Get the codomain sort of a datatype constructor sort.
     pub fn dt_constructor_codomain(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_dt_constructor_get_codomain(self.inner) })
+        Sort::from_raw(unsafe { sort_dt_constructor_get_codomain(self.inner) })
     }
 
     // -- Datatype selector sort accessors --
 
     /// Get the domain sort of a datatype selector sort.
     pub fn dt_selector_domain(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_dt_selector_get_domain(self.inner) })
+        Sort::from_raw(unsafe { sort_dt_selector_get_domain(self.inner) })
     }
 
     /// Get the codomain sort of a datatype selector sort.
     pub fn dt_selector_codomain(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_dt_selector_get_codomain(self.inner) })
+        Sort::from_raw(unsafe { sort_dt_selector_get_codomain(self.inner) })
     }
 
     // -- Datatype tester sort accessors --
 
     /// Get the domain sort of a datatype tester sort.
     pub fn dt_tester_domain(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_dt_tester_get_domain(self.inner) })
+        Sort::from_raw(unsafe { sort_dt_tester_get_domain(self.inner) })
     }
 
     /// Get the codomain sort of a datatype tester sort.
     pub fn dt_tester_codomain(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_dt_tester_get_codomain(self.inner) })
+        Sort::from_raw(unsafe { sort_dt_tester_get_codomain(self.inner) })
     }
 
     // -- Function sort accessors --
 
     /// Get the arity of a function sort.
     pub fn fun_arity(&self) -> usize {
-        unsafe { cvc5_sort_fun_get_arity(self.inner) }
+        unsafe { sort_fun_get_arity(self.inner) }
     }
 
     /// Get the domain sorts of a function sort.
     pub fn fun_domain(&self) -> Vec<Sort> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_sort_fun_get_domain(self.inner, &mut size) };
+        let ptr = unsafe { sort_fun_get_domain(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -269,57 +269,57 @@ impl Sort {
 
     /// Get the codomain sort of a function sort.
     pub fn fun_codomain(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_fun_get_codomain(self.inner) })
+        Sort::from_raw(unsafe { sort_fun_get_codomain(self.inner) })
     }
 
     // -- Array sort accessors --
 
     /// Get the index sort of an array sort.
     pub fn array_index_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_array_get_index_sort(self.inner) })
+        Sort::from_raw(unsafe { sort_array_get_index_sort(self.inner) })
     }
 
     /// Get the element sort of an array sort.
     pub fn array_element_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_array_get_element_sort(self.inner) })
+        Sort::from_raw(unsafe { sort_array_get_element_sort(self.inner) })
     }
 
     // -- Set / Bag / Sequence element sort --
 
     /// Get the element sort of a set sort.
     pub fn set_element_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_set_get_element_sort(self.inner) })
+        Sort::from_raw(unsafe { sort_set_get_element_sort(self.inner) })
     }
 
     /// Get the element sort of a bag sort.
     pub fn bag_element_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_bag_get_element_sort(self.inner) })
+        Sort::from_raw(unsafe { sort_bag_get_element_sort(self.inner) })
     }
 
     /// Get the element sort of a sequence sort.
     pub fn sequence_element_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_sequence_get_element_sort(self.inner) })
+        Sort::from_raw(unsafe { sort_sequence_get_element_sort(self.inner) })
     }
 
     // -- Abstract sort --
 
     /// Get the kind of an abstract sort.
-    pub fn abstract_kind(&self) -> Cvc5SortKind {
-        unsafe { cvc5_sort_abstract_get_kind(self.inner) }
+    pub fn abstract_kind(&self) -> cvc5_sys::SortKind {
+        unsafe { sort_abstract_get_kind(self.inner) }
     }
 
     // -- Uninterpreted sort constructor --
 
     /// Get the arity of an uninterpreted sort constructor.
     pub fn uninterpreted_sort_constructor_arity(&self) -> usize {
-        unsafe { cvc5_sort_uninterpreted_sort_constructor_get_arity(self.inner) }
+        unsafe { sort_uninterpreted_sort_constructor_get_arity(self.inner) }
     }
 
     // -- Bit-vector sort --
 
     /// Get the bit-width of a bit-vector sort.
     pub fn bv_size(&self) -> u32 {
-        unsafe { cvc5_sort_bv_get_size(self.inner) }
+        unsafe { sort_bv_get_size(self.inner) }
     }
 
     // -- Finite field sort --
@@ -327,7 +327,7 @@ impl Sort {
     /// Get the size (modulus) of a finite field sort as a string.
     pub fn ff_size(&self) -> String {
         unsafe {
-            let s = cvc5_sort_ff_get_size(self.inner);
+            let s = sort_ff_get_size(self.inner);
             std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned()
         }
     }
@@ -336,32 +336,32 @@ impl Sort {
 
     /// Get the exponent size of a floating-point sort.
     pub fn fp_exponent_size(&self) -> u32 {
-        unsafe { cvc5_sort_fp_get_exp_size(self.inner) }
+        unsafe { sort_fp_get_exp_size(self.inner) }
     }
 
     /// Get the significand size of a floating-point sort.
     pub fn fp_significand_size(&self) -> u32 {
-        unsafe { cvc5_sort_fp_get_sig_size(self.inner) }
+        unsafe { sort_fp_get_sig_size(self.inner) }
     }
 
     // -- Datatype sort --
 
     /// Get the arity of a datatype sort.
     pub fn dt_arity(&self) -> usize {
-        unsafe { cvc5_sort_dt_get_arity(self.inner) }
+        unsafe { sort_dt_get_arity(self.inner) }
     }
 
     // -- Tuple sort --
 
     /// Get the length (number of elements) of a tuple sort.
     pub fn tuple_length(&self) -> usize {
-        unsafe { cvc5_sort_tuple_get_length(self.inner) }
+        unsafe { sort_tuple_get_length(self.inner) }
     }
 
     /// Get the element sorts of a tuple sort.
     pub fn tuple_element_sorts(&self) -> Vec<Sort> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_sort_tuple_get_element_sorts(self.inner, &mut size) };
+        let ptr = unsafe { sort_tuple_get_element_sorts(self.inner, &mut size) };
         (0..size)
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -371,13 +371,13 @@ impl Sort {
 
     /// Get the element sort of a nullable sort.
     pub fn nullable_element_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_sort_nullable_get_element_sort(self.inner) })
+        Sort::from_raw(unsafe { sort_nullable_get_element_sort(self.inner) })
     }
 }
 
 impl fmt::Display for Sort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_sort_to_string(self.inner) };
+        let s = unsafe { sort_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
         write!(f, "{}", cs.to_string_lossy())
     }
@@ -391,7 +391,7 @@ impl fmt::Debug for Sort {
 
 impl PartialEq for Sort {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_sort_is_equal(self.inner, other.inner) }
+        unsafe { sort_is_equal(self.inner, other.inner) }
     }
 }
 
@@ -405,13 +405,13 @@ impl PartialOrd for Sort {
 
 impl Ord for Sort {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let c = unsafe { cvc5_sort_compare(self.inner, other.inner) };
+        let c = unsafe { sort_compare(self.inner, other.inner) };
         c.cmp(&0)
     }
 }
 
 impl std::hash::Hash for Sort {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_sort_hash(self.inner) }.hash(state);
+        unsafe { sort_hash(self.inner) }.hash(state);
     }
 }

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -4,11 +4,11 @@ use std::fmt;
 
 /// Solver statistics collected during solving.
 pub struct Statistics {
-    pub(crate) inner: Cvc5Statistics,
+    pub(crate) inner: cvc5_sys::Statistics,
 }
 
 impl Statistics {
-    pub(crate) fn from_raw(raw: Cvc5Statistics) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Statistics) -> Self {
         Self { inner: raw }
     }
 
@@ -16,7 +16,7 @@ impl Statistics {
     pub fn get(&self, name: &str) -> Stat {
         let c = CString::new(name).unwrap();
         Stat {
-            inner: unsafe { cvc5_stats_get(self.inner, c.as_ptr()) },
+            inner: unsafe { stats_get(self.inner, c.as_ptr()) },
         }
     }
 
@@ -25,18 +25,18 @@ impl Statistics {
     /// - `internal` — include internal (non-public) statistics.
     /// - `dflt` — include statistics that still have their default value.
     pub fn iter_init(&self, internal: bool, dflt: bool) {
-        unsafe { cvc5_stats_iter_init(self.inner, internal, dflt) }
+        unsafe { stats_iter_init(self.inner, internal, dflt) }
     }
 
     /// Return `true` if the iterator has more elements.
     pub fn iter_has_next(&self) -> bool {
-        unsafe { cvc5_stats_iter_has_next(self.inner) }
+        unsafe { stats_iter_has_next(self.inner) }
     }
 
     /// Advance the iterator and return the next `(name, stat)` pair.
     pub fn iter_next(&self) -> (String, Stat) {
         let mut name: *const std::os::raw::c_char = std::ptr::null();
-        let s = unsafe { cvc5_stats_iter_next(self.inner, &mut name) };
+        let s = unsafe { stats_iter_next(self.inner, &mut name) };
         let n = unsafe {
             std::ffi::CStr::from_ptr(name)
                 .to_string_lossy()
@@ -59,7 +59,7 @@ impl fmt::Debug for Statistics {
 
 impl fmt::Display for Statistics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_stats_to_string(self.inner) };
+        let s = unsafe { stats_to_string(self.inner) };
         write!(f, "{}", unsafe {
             std::ffi::CStr::from_ptr(s).to_string_lossy()
         })
@@ -68,54 +68,54 @@ impl fmt::Display for Statistics {
 
 /// A single statistic value.
 pub struct Stat {
-    pub(crate) inner: Cvc5Stat,
+    pub(crate) inner: cvc5_sys::Stat,
 }
 
 impl Stat {
     /// Return `true` if this is an internal (non-public) statistic.
     pub fn is_internal(&self) -> bool {
-        unsafe { cvc5_stat_is_internal(self.inner) }
+        unsafe { stat_is_internal(self.inner) }
     }
 
     /// Return `true` if this statistic still has its default value.
     pub fn is_default(&self) -> bool {
-        unsafe { cvc5_stat_is_default(self.inner) }
+        unsafe { stat_is_default(self.inner) }
     }
 
     /// Return `true` if this statistic holds an integer value.
     pub fn is_int(&self) -> bool {
-        unsafe { cvc5_stat_is_int(self.inner) }
+        unsafe { stat_is_int(self.inner) }
     }
 
     /// Return `true` if this statistic holds a double value.
     pub fn is_double(&self) -> bool {
-        unsafe { cvc5_stat_is_double(self.inner) }
+        unsafe { stat_is_double(self.inner) }
     }
 
     /// Return `true` if this statistic holds a string value.
     pub fn is_string(&self) -> bool {
-        unsafe { cvc5_stat_is_string(self.inner) }
+        unsafe { stat_is_string(self.inner) }
     }
 
     /// Return `true` if this statistic holds a histogram.
     pub fn is_histogram(&self) -> bool {
-        unsafe { cvc5_stat_is_histogram(self.inner) }
+        unsafe { stat_is_histogram(self.inner) }
     }
 
     /// Get the integer value of this statistic.
     pub fn get_int(&self) -> i64 {
-        unsafe { cvc5_stat_get_int(self.inner) }
+        unsafe { stat_get_int(self.inner) }
     }
 
     /// Get the double value of this statistic.
     pub fn get_double(&self) -> f64 {
-        unsafe { cvc5_stat_get_double(self.inner) }
+        unsafe { stat_get_double(self.inner) }
     }
 
     /// Get the string value of this statistic.
     pub fn get_string(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_stat_get_string(self.inner))
+            std::ffi::CStr::from_ptr(stat_get_string(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -126,7 +126,7 @@ impl Stat {
         let mut keys: *mut *const std::os::raw::c_char = std::ptr::null_mut();
         let mut values: *mut u64 = std::ptr::null_mut();
         let mut size = 0usize;
-        unsafe { cvc5_stat_get_histogram(self.inner, &mut keys, &mut values, &mut size) };
+        unsafe { stat_get_histogram(self.inner, &mut keys, &mut values, &mut size) };
         (0..size)
             .map(|i| unsafe {
                 let k = std::ffi::CStr::from_ptr(*keys.add(i))
@@ -147,7 +147,7 @@ impl fmt::Debug for Stat {
 
 impl fmt::Display for Stat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_stat_to_string(self.inner) };
+        let s = unsafe { stat_to_string(self.inner) };
         write!(f, "{}", unsafe {
             std::ffi::CStr::from_ptr(s).to_string_lossy()
         })

--- a/src/synth_result.rs
+++ b/src/synth_result.rs
@@ -3,62 +3,62 @@ use std::fmt;
 
 /// The result of a synthesis query (SyGuS).
 pub struct SynthResult {
-    pub(crate) inner: Cvc5SynthResult,
+    pub(crate) inner: cvc5_sys::SynthResult,
 }
 
 impl Clone for SynthResult {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_synth_result_copy(self.inner) },
+            inner: unsafe { synth_result_copy(self.inner) },
         }
     }
 }
 
 impl Drop for SynthResult {
     fn drop(&mut self) {
-        unsafe { cvc5_synth_result_release(self.inner) }
+        unsafe { synth_result_release(self.inner) }
     }
 }
 
 impl SynthResult {
-    pub(crate) fn from_raw(raw: Cvc5SynthResult) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::SynthResult) -> Self {
         Self { inner: raw }
     }
 
     /// Return `true` if this is a null (uninitialized) synthesis result.
     pub fn is_null(&self) -> bool {
-        unsafe { cvc5_synth_result_is_null(self.inner) }
+        unsafe { synth_result_is_null(self.inner) }
     }
 
     /// Create a copy of this synthesis result (increments the internal reference count).
     pub fn copy(&self) -> SynthResult {
-        SynthResult::from_raw(unsafe { cvc5_synth_result_copy(self.inner) })
+        SynthResult::from_raw(unsafe { synth_result_copy(self.inner) })
     }
 
     /// Check disequality with another synthesis result.
     pub fn is_disequal(&self, other: &SynthResult) -> bool {
-        unsafe { cvc5_synth_result_is_disequal(self.inner, other.inner) }
+        unsafe { synth_result_is_disequal(self.inner, other.inner) }
     }
 
     /// Return `true` if a solution was found.
     pub fn has_solution(&self) -> bool {
-        unsafe { cvc5_synth_result_has_solution(self.inner) }
+        unsafe { synth_result_has_solution(self.inner) }
     }
 
     /// Return `true` if it was determined that no solution exists.
     pub fn has_no_solution(&self) -> bool {
-        unsafe { cvc5_synth_result_has_no_solution(self.inner) }
+        unsafe { synth_result_has_no_solution(self.inner) }
     }
 
     /// Return `true` if the synthesis result is unknown.
     pub fn is_unknown(&self) -> bool {
-        unsafe { cvc5_synth_result_is_unknown(self.inner) }
+        unsafe { synth_result_is_unknown(self.inner) }
     }
 }
 
 impl fmt::Display for SynthResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_synth_result_to_string(self.inner) };
+        let s = unsafe { synth_result_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
         write!(f, "{}", cs.to_string_lossy())
     }
@@ -66,7 +66,7 @@ impl fmt::Display for SynthResult {
 
 impl PartialEq for SynthResult {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_synth_result_is_equal(self.inner, other.inner) }
+        unsafe { synth_result_is_equal(self.inner, other.inner) }
     }
 }
 
@@ -74,7 +74,7 @@ impl Eq for SynthResult {}
 
 impl std::hash::Hash for SynthResult {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_synth_result_hash(self.inner) }.hash(state);
+        unsafe { synth_result_hash(self.inner) }.hash(state);
     }
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -7,158 +7,158 @@ use crate::{Op, Sort};
 ///
 /// Terms are the main building blocks for assertions, queries, and models.
 pub struct Term {
-    pub(crate) inner: Cvc5Term,
+    pub(crate) inner: cvc5_sys::Term,
 }
 
 impl Clone for Term {
     fn clone(&self) -> Self {
         Self {
-            inner: unsafe { cvc5_term_copy(self.inner) },
+            inner: unsafe { term_copy(self.inner) },
         }
     }
 }
 
 impl Drop for Term {
     fn drop(&mut self) {
-        unsafe { cvc5_term_release(self.inner) }
+        unsafe { term_release(self.inner) }
     }
 }
 
 impl Term {
-    pub(crate) fn from_raw(raw: Cvc5Term) -> Self {
+    pub(crate) fn from_raw(raw: cvc5_sys::Term) -> Self {
         Self { inner: raw }
     }
 
     /// Get the kind of this term.
-    pub fn kind(&self) -> Cvc5Kind {
-        unsafe { cvc5_term_get_kind(self.inner) }
+    pub fn kind(&self) -> cvc5_sys::Kind {
+        unsafe { term_get_kind(self.inner) }
     }
 
     /// Create a copy of this term (increments the internal reference count).
     pub fn copy(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_term_copy(self.inner) })
+        Term::from_raw(unsafe { term_copy(self.inner) })
     }
 
     /// Check disequality with another term.
     pub fn is_disequal(&self, other: &Term) -> bool {
-        unsafe { cvc5_term_is_disequal(self.inner, other.inner) }
+        unsafe { term_is_disequal(self.inner, other.inner) }
     }
 
     /// Get the sort of this term.
     pub fn sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_term_get_sort(self.inner) })
+        Sort::from_raw(unsafe { term_get_sort(self.inner) })
     }
 
     /// Get the unique identifier of this term.
     pub fn id(&self) -> u64 {
-        unsafe { cvc5_term_get_id(self.inner) }
+        unsafe { term_get_id(self.inner) }
     }
 
     /// Get the number of children of this term.
     pub fn num_children(&self) -> usize {
-        unsafe { cvc5_term_get_num_children(self.inner) }
+        unsafe { term_get_num_children(self.inner) }
     }
 
     /// Get the child at the given index.
     pub fn child(&self, index: usize) -> Term {
-        Term::from_raw(unsafe { cvc5_term_get_child(self.inner, index) })
+        Term::from_raw(unsafe { term_get_child(self.inner, index) })
     }
 
     /// Return `true` if this term has a symbol (name).
     pub fn has_symbol(&self) -> bool {
-        unsafe { cvc5_term_has_symbol(self.inner) }
+        unsafe { term_has_symbol(self.inner) }
     }
 
     /// Get the symbol (name) of this term.
     pub fn symbol(&self) -> &str {
         unsafe {
-            let s = cvc5_term_get_symbol(self.inner);
+            let s = term_get_symbol(self.inner);
             std::ffi::CStr::from_ptr(s).to_str().unwrap_or("")
         }
     }
 
     /// Return `true` if this term has an associated operator.
     pub fn has_op(&self) -> bool {
-        unsafe { cvc5_term_has_op(self.inner) }
+        unsafe { term_has_op(self.inner) }
     }
 
     /// Get the operator associated with this term.
     pub fn op(&self) -> Op {
-        Op::from_raw(unsafe { cvc5_term_get_op(self.inner) })
+        Op::from_raw(unsafe { term_get_op(self.inner) })
     }
 
     /// Substitute `t` with `replacement` in this term.
     pub fn substitute_term(&self, t: Term, replacement: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_term_substitute_term(self.inner, t.inner, replacement.inner) })
+        Term::from_raw(unsafe { term_substitute_term(self.inner, t.inner, replacement.inner) })
     }
 
     /// Simultaneously substitute `terms` with `replacements` in this term.
     pub fn substitute_terms(&self, terms: &[Term], replacements: &[Term]) -> Term {
-        let t: Vec<Cvc5Term> = terms.iter().map(|t| t.inner).collect();
-        let r: Vec<Cvc5Term> = replacements.iter().map(|t| t.inner).collect();
+        let t: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
+        let r: Vec<cvc5_sys::Term> = replacements.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_term_substitute_terms(self.inner, t.len(), t.as_ptr(), r.as_ptr())
+            term_substitute_terms(self.inner, t.len(), t.as_ptr(), r.as_ptr())
         })
     }
 
     /// Get the sign of a real or integer value: -1, 0, or 1.
     pub fn real_or_integer_value_sign(&self) -> i32 {
-        unsafe { cvc5_term_get_real_or_integer_value_sign(self.inner) }
+        unsafe { term_get_real_or_integer_value_sign(self.inner) }
     }
 
     /// Return `true` if this term is a Boolean value.
     pub fn is_boolean_value(&self) -> bool {
-        unsafe { cvc5_term_is_boolean_value(self.inner) }
+        unsafe { term_is_boolean_value(self.inner) }
     }
     /// Get the Boolean value of this term.
     pub fn boolean_value(&self) -> bool {
-        unsafe { cvc5_term_get_boolean_value(self.inner) }
+        unsafe { term_get_boolean_value(self.inner) }
     }
 
     /// Return `true` if this term is a 32-bit signed integer value.
     pub fn is_int32_value(&self) -> bool {
-        unsafe { cvc5_term_is_int32_value(self.inner) }
+        unsafe { term_is_int32_value(self.inner) }
     }
     /// Get the 32-bit signed integer value.
     pub fn int32_value(&self) -> i32 {
-        unsafe { cvc5_term_get_int32_value(self.inner) }
+        unsafe { term_get_int32_value(self.inner) }
     }
 
     /// Return `true` if this term is a 32-bit unsigned integer value.
     pub fn is_uint32_value(&self) -> bool {
-        unsafe { cvc5_term_is_uint32_value(self.inner) }
+        unsafe { term_is_uint32_value(self.inner) }
     }
     /// Get the 32-bit unsigned integer value.
     pub fn uint32_value(&self) -> u32 {
-        unsafe { cvc5_term_get_uint32_value(self.inner) }
+        unsafe { term_get_uint32_value(self.inner) }
     }
 
     /// Return `true` if this term is a 64-bit signed integer value.
     pub fn is_int64_value(&self) -> bool {
-        unsafe { cvc5_term_is_int64_value(self.inner) }
+        unsafe { term_is_int64_value(self.inner) }
     }
     /// Get the 64-bit signed integer value.
     pub fn int64_value(&self) -> i64 {
-        unsafe { cvc5_term_get_int64_value(self.inner) }
+        unsafe { term_get_int64_value(self.inner) }
     }
 
     /// Return `true` if this term is a 64-bit unsigned integer value.
     pub fn is_uint64_value(&self) -> bool {
-        unsafe { cvc5_term_is_uint64_value(self.inner) }
+        unsafe { term_is_uint64_value(self.inner) }
     }
     /// Get the 64-bit unsigned integer value.
     pub fn uint64_value(&self) -> u64 {
-        unsafe { cvc5_term_get_uint64_value(self.inner) }
+        unsafe { term_get_uint64_value(self.inner) }
     }
 
     /// Return `true` if this term is an arbitrary-precision integer value.
     pub fn is_integer_value(&self) -> bool {
-        unsafe { cvc5_term_is_integer_value(self.inner) }
+        unsafe { term_is_integer_value(self.inner) }
     }
     /// Get the integer value as a decimal string.
     pub fn integer_value(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_term_get_integer_value(self.inner))
+            std::ffi::CStr::from_ptr(term_get_integer_value(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -166,11 +166,11 @@ impl Term {
 
     /// Return `true` if this term is a string value.
     pub fn is_string_value(&self) -> bool {
-        unsafe { cvc5_term_is_string_value(self.inner) }
+        unsafe { term_is_string_value(self.inner) }
     }
     /// Get the string value as a sequence of `wchar_t` code points.
     pub fn string_value(&self) -> Vec<char32_t> {
-        let ptr = unsafe { cvc5_term_get_string_value(self.inner) };
+        let ptr = unsafe { term_get_string_value(self.inner) };
         let mut v = Vec::new();
         let mut i = 0;
         loop {
@@ -185,7 +185,7 @@ impl Term {
     }
     /// Get the string value as a sequence of Unicode code points (`char32_t`).
     pub fn u32string_value(&self) -> Vec<char32_t> {
-        let ptr = unsafe { cvc5_term_get_u32string_value(self.inner) };
+        let ptr = unsafe { term_get_u32string_value(self.inner) };
         let mut v = Vec::new();
         let mut i = 0;
         loop {
@@ -201,34 +201,34 @@ impl Term {
 
     /// Return `true` if this term is a rational value representable as 32-bit `(num, den)`.
     pub fn is_real32_value(&self) -> bool {
-        unsafe { cvc5_term_is_real32_value(self.inner) }
+        unsafe { term_is_real32_value(self.inner) }
     }
     /// Get the rational value as `(numerator, denominator)` with 32-bit components.
     pub fn real32_value(&self) -> (i32, u32) {
         let (mut num, mut den) = (0i32, 0u32);
-        unsafe { cvc5_term_get_real32_value(self.inner, &mut num, &mut den) };
+        unsafe { term_get_real32_value(self.inner, &mut num, &mut den) };
         (num, den)
     }
 
     /// Return `true` if this term is a rational value representable as 64-bit `(num, den)`.
     pub fn is_real64_value(&self) -> bool {
-        unsafe { cvc5_term_is_real64_value(self.inner) }
+        unsafe { term_is_real64_value(self.inner) }
     }
     /// Get the rational value as `(numerator, denominator)` with 64-bit components.
     pub fn real64_value(&self) -> (i64, u64) {
         let (mut num, mut den) = (0i64, 0u64);
-        unsafe { cvc5_term_get_real64_value(self.inner, &mut num, &mut den) };
+        unsafe { term_get_real64_value(self.inner, &mut num, &mut den) };
         (num, den)
     }
 
     /// Return `true` if this term is an arbitrary-precision real value.
     pub fn is_real_value(&self) -> bool {
-        unsafe { cvc5_term_is_real_value(self.inner) }
+        unsafe { term_is_real_value(self.inner) }
     }
     /// Get the real value as a decimal string (e.g. `"1/3"`).
     pub fn real_value(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_term_get_real_value(self.inner))
+            std::ffi::CStr::from_ptr(term_get_real_value(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -236,21 +236,21 @@ impl Term {
 
     /// Return `true` if this term is a constant array value.
     pub fn is_const_array(&self) -> bool {
-        unsafe { cvc5_term_is_const_array(self.inner) }
+        unsafe { term_is_const_array(self.inner) }
     }
     /// Get the base (default) value of a constant array.
     pub fn const_array_base(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_term_get_const_array_base(self.inner) })
+        Term::from_raw(unsafe { term_get_const_array_base(self.inner) })
     }
 
     /// Return `true` if this term is a bit-vector value.
     pub fn is_bv_value(&self) -> bool {
-        unsafe { cvc5_term_is_bv_value(self.inner) }
+        unsafe { term_is_bv_value(self.inner) }
     }
     /// Get the bit-vector value as a string in the given base (2, 10, or 16).
     pub fn bv_value(&self, base: u32) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_term_get_bv_value(self.inner, base))
+            std::ffi::CStr::from_ptr(term_get_bv_value(self.inner, base))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -258,12 +258,12 @@ impl Term {
 
     /// Return `true` if this term is a finite field value.
     pub fn is_ff_value(&self) -> bool {
-        unsafe { cvc5_term_is_ff_value(self.inner) }
+        unsafe { term_is_ff_value(self.inner) }
     }
     /// Get the finite field value as a string.
     pub fn ff_value(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_term_get_ff_value(self.inner))
+            std::ffi::CStr::from_ptr(term_get_ff_value(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -271,12 +271,12 @@ impl Term {
 
     /// Return `true` if this term is an uninterpreted sort value.
     pub fn is_uninterpreted_sort_value(&self) -> bool {
-        unsafe { cvc5_term_is_uninterpreted_sort_value(self.inner) }
+        unsafe { term_is_uninterpreted_sort_value(self.inner) }
     }
     /// Get the uninterpreted sort value as a string.
     pub fn uninterpreted_sort_value(&self) -> String {
         unsafe {
-            std::ffi::CStr::from_ptr(cvc5_term_get_uninterpreted_sort_value(self.inner))
+            std::ffi::CStr::from_ptr(term_get_uninterpreted_sort_value(self.inner))
                 .to_string_lossy()
                 .into_owned()
         }
@@ -284,12 +284,12 @@ impl Term {
 
     /// Return `true` if this term is a tuple value.
     pub fn is_tuple_value(&self) -> bool {
-        unsafe { cvc5_term_is_tuple_value(self.inner) }
+        unsafe { term_is_tuple_value(self.inner) }
     }
     /// Get the elements of a tuple value.
     pub fn tuple_value(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_term_get_tuple_value(self.inner, &mut size) };
+        let ptr = unsafe { term_get_tuple_value(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -297,53 +297,53 @@ impl Term {
 
     /// Return `true` if this term is a rounding mode value.
     pub fn is_rm_value(&self) -> bool {
-        unsafe { cvc5_term_is_rm_value(self.inner) }
+        unsafe { term_is_rm_value(self.inner) }
     }
     /// Get the rounding mode value.
-    pub fn rm_value(&self) -> Cvc5RoundingMode {
-        unsafe { cvc5_term_get_rm_value(self.inner) }
+    pub fn rm_value(&self) -> cvc5_sys::RoundingMode {
+        unsafe { term_get_rm_value(self.inner) }
     }
 
     /// Return `true` if this term is positive zero (`+0.0`).
     pub fn is_fp_pos_zero(&self) -> bool {
-        unsafe { cvc5_term_is_fp_pos_zero(self.inner) }
+        unsafe { term_is_fp_pos_zero(self.inner) }
     }
     /// Return `true` if this term is negative zero (`-0.0`).
     pub fn is_fp_neg_zero(&self) -> bool {
-        unsafe { cvc5_term_is_fp_neg_zero(self.inner) }
+        unsafe { term_is_fp_neg_zero(self.inner) }
     }
     /// Return `true` if this term is positive infinity.
     pub fn is_fp_pos_inf(&self) -> bool {
-        unsafe { cvc5_term_is_fp_pos_inf(self.inner) }
+        unsafe { term_is_fp_pos_inf(self.inner) }
     }
     /// Return `true` if this term is negative infinity.
     pub fn is_fp_neg_inf(&self) -> bool {
-        unsafe { cvc5_term_is_fp_neg_inf(self.inner) }
+        unsafe { term_is_fp_neg_inf(self.inner) }
     }
     /// Return `true` if this term is NaN.
     pub fn is_fp_nan(&self) -> bool {
-        unsafe { cvc5_term_is_fp_nan(self.inner) }
+        unsafe { term_is_fp_nan(self.inner) }
     }
     /// Return `true` if this term is a floating-point value.
     pub fn is_fp_value(&self) -> bool {
-        unsafe { cvc5_term_is_fp_value(self.inner) }
+        unsafe { term_is_fp_value(self.inner) }
     }
     /// Get the floating-point value as `(exponent_width, significand_width, bit_vector_value)`.
     pub fn fp_value(&self) -> (u32, u32, Term) {
         let (mut ew, mut sw) = (0u32, 0u32);
         let mut val = std::ptr::null_mut();
-        unsafe { cvc5_term_get_fp_value(self.inner, &mut ew, &mut sw, &mut val) };
+        unsafe { term_get_fp_value(self.inner, &mut ew, &mut sw, &mut val) };
         (ew, sw, Term::from_raw(val))
     }
 
     /// Return `true` if this term is a set value.
     pub fn is_set_value(&self) -> bool {
-        unsafe { cvc5_term_is_set_value(self.inner) }
+        unsafe { term_is_set_value(self.inner) }
     }
     /// Get the elements of a set value.
     pub fn set_value(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_term_get_set_value(self.inner, &mut size) };
+        let ptr = unsafe { term_get_set_value(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -351,12 +351,12 @@ impl Term {
 
     /// Return `true` if this term is a sequence value.
     pub fn is_sequence_value(&self) -> bool {
-        unsafe { cvc5_term_is_sequence_value(self.inner) }
+        unsafe { term_is_sequence_value(self.inner) }
     }
     /// Get the elements of a sequence value.
     pub fn sequence_value(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_term_get_sequence_value(self.inner, &mut size) };
+        let ptr = unsafe { term_get_sequence_value(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -364,47 +364,47 @@ impl Term {
 
     /// Return `true` if this term is a cardinality constraint.
     pub fn is_cardinality_constraint(&self) -> bool {
-        unsafe { cvc5_term_is_cardinality_constraint(self.inner) }
+        unsafe { term_is_cardinality_constraint(self.inner) }
     }
     /// Get the sort and upper bound of a cardinality constraint.
     pub fn cardinality_constraint(&self) -> (Sort, u32) {
         let mut sort = std::ptr::null_mut();
         let mut upper = 0u32;
-        unsafe { cvc5_term_get_cardinality_constraint(self.inner, &mut sort, &mut upper) };
+        unsafe { term_get_cardinality_constraint(self.inner, &mut sort, &mut upper) };
         (Sort::from_raw(sort), upper)
     }
 
     /// Return `true` if this term is a real algebraic number.
     pub fn is_real_algebraic_number(&self) -> bool {
-        unsafe { cvc5_term_is_real_algebraic_number(self.inner) }
+        unsafe { term_is_real_algebraic_number(self.inner) }
     }
     /// Get the defining polynomial of a real algebraic number in terms of variable `v`.
     pub fn real_algebraic_number_defining_polynomial(&self, v: Term) -> Term {
         Term::from_raw(unsafe {
-            cvc5_term_get_real_algebraic_number_defining_polynomial(self.inner, v.inner)
+            term_get_real_algebraic_number_defining_polynomial(self.inner, v.inner)
         })
     }
     /// Get the lower bound of the isolating interval of a real algebraic number.
     pub fn real_algebraic_number_lower_bound(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_term_get_real_algebraic_number_lower_bound(self.inner) })
+        Term::from_raw(unsafe { term_get_real_algebraic_number_lower_bound(self.inner) })
     }
     /// Get the upper bound of the isolating interval of a real algebraic number.
     pub fn real_algebraic_number_upper_bound(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_term_get_real_algebraic_number_upper_bound(self.inner) })
+        Term::from_raw(unsafe { term_get_real_algebraic_number_upper_bound(self.inner) })
     }
 
     /// Return `true` if this term is a Skolem.
     pub fn is_skolem(&self) -> bool {
-        unsafe { cvc5_term_is_skolem(self.inner) }
+        unsafe { term_is_skolem(self.inner) }
     }
     /// Get the Skolem identifier of this term.
-    pub fn skolem_id(&self) -> Cvc5SkolemId {
-        unsafe { cvc5_term_get_skolem_id(self.inner) }
+    pub fn skolem_id(&self) -> cvc5_sys::SkolemId {
+        unsafe { term_get_skolem_id(self.inner) }
     }
     /// Get the indices of this Skolem term.
     pub fn skolem_indices(&self) -> Vec<Term> {
         let mut size = 0usize;
-        let ptr = unsafe { cvc5_term_get_skolem_indices(self.inner, &mut size) };
+        let ptr = unsafe { term_get_skolem_indices(self.inner, &mut size) };
         (0..size)
             .map(|i| Term::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -413,7 +413,7 @@ impl Term {
 
 impl fmt::Display for Term {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = unsafe { cvc5_term_to_string(self.inner) };
+        let s = unsafe { term_to_string(self.inner) };
         let cs = unsafe { std::ffi::CStr::from_ptr(s) };
         write!(f, "{}", cs.to_string_lossy())
     }
@@ -427,7 +427,7 @@ impl fmt::Debug for Term {
 
 impl PartialEq for Term {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { cvc5_term_is_equal(self.inner, other.inner) }
+        unsafe { term_is_equal(self.inner, other.inner) }
     }
 }
 
@@ -441,13 +441,13 @@ impl PartialOrd for Term {
 
 impl Ord for Term {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let c = unsafe { cvc5_term_compare(self.inner, other.inner) };
+        let c = unsafe { term_compare(self.inner, other.inner) };
         c.cmp(&0)
     }
 }
 
 impl std::hash::Hash for Term {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe { cvc5_term_hash(self.inner) }.hash(state);
+        unsafe { term_hash(self.inner) }.hash(state);
     }
 }

--- a/src/term_manager.rs
+++ b/src/term_manager.rs
@@ -11,24 +11,24 @@ use crate::{DatatypeConstructorDecl, DatatypeDecl, Op, Sort, Statistics, Term};
 /// cheaply cloned and shared while still allowing mutation through `&self`.
 #[derive(Clone)]
 pub struct TermManager {
-    pub(crate) inner: Rc<RefCell<*mut Cvc5TermManager>>,
+    pub(crate) inner: Rc<RefCell<*mut cvc5_sys::TermManager>>,
 }
 
 impl TermManager {
     /// Create a new term manager.
     pub fn new() -> Self {
         Self {
-            inner: Rc::new(RefCell::new(unsafe { cvc5_term_manager_new() })),
+            inner: Rc::new(RefCell::new(unsafe { term_manager_new() })),
         }
     }
 
     /// Raw pointer for read-only access.
-    pub(crate) fn ptr(&self) -> *mut Cvc5TermManager {
+    pub(crate) fn ptr(&self) -> *mut cvc5_sys::TermManager {
         *self.inner.borrow()
     }
 
     /// Raw pointer for mutating access.
-    pub(crate) fn ptr_mut(&self) -> *mut Cvc5TermManager {
+    pub(crate) fn ptr_mut(&self) -> *mut cvc5_sys::TermManager {
         *self.inner.borrow_mut()
     }
 
@@ -36,59 +36,59 @@ impl TermManager {
 
     /// Get the Boolean sort.
     pub fn boolean_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_get_boolean_sort(self.ptr()) })
+        Sort::from_raw(unsafe { get_boolean_sort(self.ptr()) })
     }
     /// Get the Integer sort.
     pub fn integer_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_get_integer_sort(self.ptr()) })
+        Sort::from_raw(unsafe { get_integer_sort(self.ptr()) })
     }
     /// Get the Real sort.
     pub fn real_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_get_real_sort(self.ptr()) })
+        Sort::from_raw(unsafe { get_real_sort(self.ptr()) })
     }
     /// Get the String sort.
     pub fn string_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_get_string_sort(self.ptr()) })
+        Sort::from_raw(unsafe { get_string_sort(self.ptr()) })
     }
     /// Get the RegExp sort.
     pub fn regexp_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_get_regexp_sort(self.ptr()) })
+        Sort::from_raw(unsafe { get_regexp_sort(self.ptr()) })
     }
     /// Get the rounding mode sort.
     pub fn rm_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_get_rm_sort(self.ptr()) })
+        Sort::from_raw(unsafe { get_rm_sort(self.ptr()) })
     }
 
     /// Create an array sort with the given index and element sorts.
     pub fn mk_array_sort(&self, index: Sort, elem: Sort) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_array_sort(self.ptr_mut(), index.inner, elem.inner) })
+        Sort::from_raw(unsafe { mk_array_sort(self.ptr_mut(), index.inner, elem.inner) })
     }
 
     /// Create a bit-vector sort of the given bit-width.
     pub fn mk_bv_sort(&self, size: u32) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_bv_sort(self.ptr_mut(), size) })
+        Sort::from_raw(unsafe { mk_bv_sort(self.ptr_mut(), size) })
     }
 
     /// Create a floating-point sort with the given exponent and significand sizes.
     pub fn mk_fp_sort(&self, exp: u32, sig: u32) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_fp_sort(self.ptr_mut(), exp, sig) })
+        Sort::from_raw(unsafe { mk_fp_sort(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a finite field sort of the given size (modulus) in the given base.
     pub fn mk_ff_sort(&self, size: &str, base: u32) -> Sort {
         let c = CString::new(size).unwrap();
-        Sort::from_raw(unsafe { cvc5_mk_ff_sort(self.ptr_mut(), c.as_ptr(), base) })
+        Sort::from_raw(unsafe { mk_ff_sort(self.ptr_mut(), c.as_ptr(), base) })
     }
 
     /// Create a datatype sort from a datatype declaration.
     pub fn mk_dt_sort(&self, decl: &DatatypeDecl) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_dt_sort(self.ptr_mut(), decl.inner) })
+        Sort::from_raw(unsafe { mk_dt_sort(self.ptr_mut(), decl.inner) })
     }
 
     /// Create mutually recursive datatype sorts from declarations.
     pub fn mk_dt_sorts(&self, decls: &[DatatypeDecl]) -> Vec<Sort> {
-        let raw: Vec<Cvc5DatatypeDecl> = decls.iter().map(|d| d.inner).collect();
-        let ptr = unsafe { cvc5_mk_dt_sorts(self.ptr_mut(), raw.len(), raw.as_ptr()) };
+        let raw: Vec<cvc5_sys::DatatypeDecl> = decls.iter().map(|d| d.inner).collect();
+        let ptr = unsafe { mk_dt_sorts(self.ptr_mut(), raw.len(), raw.as_ptr()) };
         (0..decls.len())
             .map(|i| Sort::from_raw(unsafe { *ptr.add(i) }))
             .collect()
@@ -96,339 +96,335 @@ impl TermManager {
 
     /// Create a function sort with the given domain and codomain sorts.
     pub fn mk_fun_sort(&self, domain: &[Sort], codomain: Sort) -> Sort {
-        let raw: Vec<Cvc5Sort> = domain.iter().map(|s| s.inner).collect();
+        let raw: Vec<cvc5_sys::Sort> = domain.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe {
-            cvc5_mk_fun_sort(self.ptr_mut(), raw.len(), raw.as_ptr(), codomain.inner)
+            mk_fun_sort(self.ptr_mut(), raw.len(), raw.as_ptr(), codomain.inner)
         })
     }
 
     /// Create a sort parameter with the given symbol.
     pub fn mk_param_sort(&self, symbol: &str) -> Sort {
         let c = CString::new(symbol).unwrap();
-        Sort::from_raw(unsafe { cvc5_mk_param_sort(self.ptr_mut(), c.as_ptr()) })
+        Sort::from_raw(unsafe { mk_param_sort(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a predicate sort (function sort with Boolean codomain).
     pub fn mk_predicate_sort(&self, sorts: &[Sort]) -> Sort {
-        let raw: Vec<Cvc5Sort> = sorts.iter().map(|s| s.inner).collect();
-        Sort::from_raw(unsafe { cvc5_mk_predicate_sort(self.ptr_mut(), raw.len(), raw.as_ptr()) })
+        let raw: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
+        Sort::from_raw(unsafe { mk_predicate_sort(self.ptr_mut(), raw.len(), raw.as_ptr()) })
     }
 
     /// Create a record sort with the given field names and sorts.
     pub fn mk_record_sort(&self, names: &[&str], sorts: &[Sort]) -> Sort {
         let cnames: Vec<CString> = names.iter().map(|n| CString::new(*n).unwrap()).collect();
         let mut ptrs: Vec<*const std::ffi::c_char> = cnames.iter().map(|c| c.as_ptr()).collect();
-        let raw: Vec<Cvc5Sort> = sorts.iter().map(|s| s.inner).collect();
+        let raw: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
         Sort::from_raw(unsafe {
-            cvc5_mk_record_sort(self.ptr_mut(), raw.len(), ptrs.as_mut_ptr(), raw.as_ptr())
+            mk_record_sort(self.ptr_mut(), raw.len(), ptrs.as_mut_ptr(), raw.as_ptr())
         })
     }
 
     /// Create a set sort with the given element sort.
     pub fn mk_set_sort(&self, elem: Sort) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_set_sort(self.ptr_mut(), elem.inner) })
+        Sort::from_raw(unsafe { mk_set_sort(self.ptr_mut(), elem.inner) })
     }
 
     /// Create a bag sort with the given element sort.
     pub fn mk_bag_sort(&self, elem: Sort) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_bag_sort(self.ptr_mut(), elem.inner) })
+        Sort::from_raw(unsafe { mk_bag_sort(self.ptr_mut(), elem.inner) })
     }
 
     /// Create a sequence sort with the given element sort.
     pub fn mk_sequence_sort(&self, elem: Sort) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_sequence_sort(self.ptr_mut(), elem.inner) })
+        Sort::from_raw(unsafe { mk_sequence_sort(self.ptr_mut(), elem.inner) })
     }
 
     /// Create an abstract sort of the given sort kind.
-    pub fn mk_abstract_sort(&self, k: Cvc5SortKind) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_abstract_sort(self.ptr_mut(), k) })
+    pub fn mk_abstract_sort(&self, k: cvc5_sys::SortKind) -> Sort {
+        Sort::from_raw(unsafe { mk_abstract_sort(self.ptr_mut(), k) })
     }
 
     /// Create a named uninterpreted sort.
     pub fn mk_uninterpreted_sort(&self, name: &str) -> Sort {
         let c = CString::new(name).unwrap();
-        Sort::from_raw(unsafe { cvc5_mk_uninterpreted_sort(self.ptr_mut(), c.as_ptr()) })
+        Sort::from_raw(unsafe { mk_uninterpreted_sort(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create an anonymous uninterpreted sort (no symbol).
     pub fn mk_anonymous_uninterpreted_sort(&self) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_uninterpreted_sort(self.ptr_mut(), std::ptr::null()) })
+        Sort::from_raw(unsafe { mk_uninterpreted_sort(self.ptr_mut(), std::ptr::null()) })
     }
 
     /// Create an unresolved datatype sort placeholder for mutual recursion.
     pub fn mk_unresolved_dt_sort(&self, symbol: &str, arity: usize) -> Sort {
         let c = CString::new(symbol).unwrap();
-        Sort::from_raw(unsafe { cvc5_mk_unresolved_dt_sort(self.ptr_mut(), c.as_ptr(), arity) })
+        Sort::from_raw(unsafe { mk_unresolved_dt_sort(self.ptr_mut(), c.as_ptr(), arity) })
     }
 
     /// Create an uninterpreted sort constructor of the given arity.
     pub fn mk_uninterpreted_sort_constructor_sort(&self, arity: usize, symbol: &str) -> Sort {
         let c = CString::new(symbol).unwrap();
         Sort::from_raw(unsafe {
-            cvc5_mk_uninterpreted_sort_constructor_sort(self.ptr_mut(), arity, c.as_ptr())
+            mk_uninterpreted_sort_constructor_sort(self.ptr_mut(), arity, c.as_ptr())
         })
     }
 
     /// Create an anonymous uninterpreted sort constructor of the given arity.
     pub fn mk_anonymous_uninterpreted_sort_constructor_sort(&self, arity: usize) -> Sort {
         Sort::from_raw(unsafe {
-            cvc5_mk_uninterpreted_sort_constructor_sort(self.ptr_mut(), arity, std::ptr::null())
+            mk_uninterpreted_sort_constructor_sort(self.ptr_mut(), arity, std::ptr::null())
         })
     }
 
     /// Create a tuple sort with the given element sorts.
     pub fn mk_tuple_sort(&self, sorts: &[Sort]) -> Sort {
-        let raw: Vec<Cvc5Sort> = sorts.iter().map(|s| s.inner).collect();
-        Sort::from_raw(unsafe { cvc5_mk_tuple_sort(self.ptr_mut(), raw.len(), raw.as_ptr()) })
+        let raw: Vec<cvc5_sys::Sort> = sorts.iter().map(|s| s.inner).collect();
+        Sort::from_raw(unsafe { mk_tuple_sort(self.ptr_mut(), raw.len(), raw.as_ptr()) })
     }
 
     /// Create a nullable sort wrapping the given sort.
     pub fn mk_nullable_sort(&self, sort: Sort) -> Sort {
-        Sort::from_raw(unsafe { cvc5_mk_nullable_sort(self.ptr_mut(), sort.inner) })
+        Sort::from_raw(unsafe { mk_nullable_sort(self.ptr_mut(), sort.inner) })
     }
 
     // ── Operator creation ──────────────────────────────────────────
 
     /// Create an indexed operator with the given kind and integer indices.
-    pub fn mk_op(&self, kind: Cvc5Kind, indices: &[u32]) -> Op {
-        Op::from_raw(unsafe { cvc5_mk_op(self.ptr_mut(), kind, indices.len(), indices.as_ptr()) })
+    pub fn mk_op(&self, kind: cvc5_sys::Kind, indices: &[u32]) -> Op {
+        Op::from_raw(unsafe { mk_op(self.ptr_mut(), kind, indices.len(), indices.as_ptr()) })
     }
 
     /// Create an indexed operator with the given kind and string argument.
-    pub fn mk_op_from_str(&self, kind: Cvc5Kind, arg: &str) -> Op {
+    pub fn mk_op_from_str(&self, kind: cvc5_sys::Kind, arg: &str) -> Op {
         let c = CString::new(arg).unwrap();
-        Op::from_raw(unsafe { cvc5_mk_op_from_str(self.ptr_mut(), kind, c.as_ptr()) })
+        Op::from_raw(unsafe { mk_op_from_str(self.ptr_mut(), kind, c.as_ptr()) })
     }
 
     // ── Term creation ──────────────────────────────────────────────
 
     /// Create a term with the given kind and children.
-    pub fn mk_term(&self, kind: Cvc5Kind, children: &[Term]) -> Term {
-        let raw: Vec<Cvc5Term> = children.iter().map(|t| t.inner).collect();
-        Term::from_raw(unsafe { cvc5_mk_term(self.ptr_mut(), kind, raw.len(), raw.as_ptr()) })
+    pub fn mk_term(&self, kind: cvc5_sys::Kind, children: &[Term]) -> Term {
+        let raw: Vec<cvc5_sys::Term> = children.iter().map(|t| t.inner).collect();
+        Term::from_raw(unsafe { mk_term(self.ptr_mut(), kind, raw.len(), raw.as_ptr()) })
     }
 
     /// Create a term from an operator and children.
     pub fn mk_term_from_op(&self, op: Op, children: &[Term]) -> Term {
-        let raw: Vec<Cvc5Term> = children.iter().map(|t| t.inner).collect();
+        let raw: Vec<cvc5_sys::Term> = children.iter().map(|t| t.inner).collect();
         Term::from_raw(unsafe {
-            cvc5_mk_term_from_op(self.ptr_mut(), op.inner, raw.len(), raw.as_ptr())
+            mk_term_from_op(self.ptr_mut(), op.inner, raw.len(), raw.as_ptr())
         })
     }
 
     /// Create a tuple term from the given elements.
     pub fn mk_tuple(&self, terms: &[Term]) -> Term {
-        let raw: Vec<Cvc5Term> = terms.iter().map(|t| t.inner).collect();
-        Term::from_raw(unsafe { cvc5_mk_tuple(self.ptr_mut(), raw.len(), raw.as_ptr()) })
+        let raw: Vec<cvc5_sys::Term> = terms.iter().map(|t| t.inner).collect();
+        Term::from_raw(unsafe { mk_tuple(self.ptr_mut(), raw.len(), raw.as_ptr()) })
     }
 
     /// Create a nullable term wrapping the given value.
     pub fn mk_nullable_some(&self, term: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_nullable_some(self.ptr_mut(), term.inner) })
+        Term::from_raw(unsafe { mk_nullable_some(self.ptr_mut(), term.inner) })
     }
 
     /// Extract the value from a nullable term.
     pub fn mk_nullable_val(&self, term: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_nullable_val(self.ptr_mut(), term.inner) })
+        Term::from_raw(unsafe { mk_nullable_val(self.ptr_mut(), term.inner) })
     }
 
     /// Create a term testing whether a nullable is null.
     pub fn mk_nullable_is_null(&self, term: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_nullable_is_null(self.ptr_mut(), term.inner) })
+        Term::from_raw(unsafe { mk_nullable_is_null(self.ptr_mut(), term.inner) })
     }
 
     /// Create a term testing whether a nullable has a value.
     pub fn mk_nullable_is_some(&self, term: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_nullable_is_some(self.ptr_mut(), term.inner) })
+        Term::from_raw(unsafe { mk_nullable_is_some(self.ptr_mut(), term.inner) })
     }
 
     /// Create a null nullable term of the given sort.
     pub fn mk_nullable_null(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_nullable_null(self.ptr_mut(), sort.inner) })
+        Term::from_raw(unsafe { mk_nullable_null(self.ptr_mut(), sort.inner) })
     }
 
     /// Lift an operator over nullable arguments.
-    pub fn mk_nullable_lift(&self, kind: Cvc5Kind, args: &[Term]) -> Term {
-        let raw: Vec<Cvc5Term> = args.iter().map(|t| t.inner).collect();
-        Term::from_raw(unsafe {
-            cvc5_mk_nullable_lift(self.ptr_mut(), kind, raw.len(), raw.as_ptr())
-        })
+    pub fn mk_nullable_lift(&self, kind: cvc5_sys::Kind, args: &[Term]) -> Term {
+        let raw: Vec<cvc5_sys::Term> = args.iter().map(|t| t.inner).collect();
+        Term::from_raw(unsafe { mk_nullable_lift(self.ptr_mut(), kind, raw.len(), raw.as_ptr()) })
     }
 
     /// Create a Skolem term with the given identifier and indices.
-    pub fn mk_skolem(&self, id: Cvc5SkolemId, indices: &[Term]) -> Term {
-        let raw: Vec<Cvc5Term> = indices.iter().map(|t| t.inner).collect();
-        Term::from_raw(unsafe { cvc5_mk_skolem(self.ptr_mut(), id, raw.len(), raw.as_ptr()) })
+    pub fn mk_skolem(&self, id: cvc5_sys::SkolemId, indices: &[Term]) -> Term {
+        let raw: Vec<cvc5_sys::Term> = indices.iter().map(|t| t.inner).collect();
+        Term::from_raw(unsafe { mk_skolem(self.ptr_mut(), id, raw.len(), raw.as_ptr()) })
     }
 
     /// Get the number of indices expected for the given Skolem identifier.
-    pub fn get_num_idxs_for_skolem_id(&self, id: Cvc5SkolemId) -> usize {
-        unsafe { cvc5_get_num_idxs_for_skolem_id(self.ptr(), id) }
+    pub fn get_num_idxs_for_skolem_id(&self, id: cvc5_sys::SkolemId) -> usize {
+        unsafe { get_num_idxs_for_skolem_id(self.ptr(), id) }
     }
 
     // ── Constants ──────────────────────────────────────────────────
 
     /// Create the Boolean constant `true`.
     pub fn mk_true(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_true(self.ptr_mut()) })
+        Term::from_raw(unsafe { mk_true(self.ptr_mut()) })
     }
     /// Create the Boolean constant `false`.
     pub fn mk_false(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_false(self.ptr_mut()) })
+        Term::from_raw(unsafe { mk_false(self.ptr_mut()) })
     }
     /// Create a Boolean constant from a Rust `bool`.
     pub fn mk_boolean(&self, val: bool) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_boolean(self.ptr_mut(), val) })
+        Term::from_raw(unsafe { mk_boolean(self.ptr_mut(), val) })
     }
     /// Create the constant pi.
     pub fn mk_pi(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_pi(self.ptr_mut()) })
+        Term::from_raw(unsafe { mk_pi(self.ptr_mut()) })
     }
 
     /// Create an integer constant from an `i64`.
     pub fn mk_integer(&self, val: i64) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_integer_int64(self.ptr_mut(), val) })
+        Term::from_raw(unsafe { mk_integer_int64(self.ptr_mut(), val) })
     }
 
     /// Create an integer constant from a decimal string.
     pub fn mk_integer_from_str(&self, s: &str) -> Term {
         let c = CString::new(s).unwrap();
-        Term::from_raw(unsafe { cvc5_mk_integer(self.ptr_mut(), c.as_ptr()) })
+        Term::from_raw(unsafe { mk_integer(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a real constant from an `i64`.
     pub fn mk_real(&self, val: i64) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_real_int64(self.ptr_mut(), val) })
+        Term::from_raw(unsafe { mk_real_int64(self.ptr_mut(), val) })
     }
 
     /// Create a real constant from a decimal string.
     pub fn mk_real_from_str(&self, s: &str) -> Term {
         let c = CString::new(s).unwrap();
-        Term::from_raw(unsafe { cvc5_mk_real(self.ptr_mut(), c.as_ptr()) })
+        Term::from_raw(unsafe { mk_real(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a real constant from a numerator and denominator.
     pub fn mk_real_from_rational(&self, num: i64, den: i64) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_real_num_den(self.ptr_mut(), num, den) })
+        Term::from_raw(unsafe { mk_real_num_den(self.ptr_mut(), num, den) })
     }
 
     /// Create the regular expression that matches everything (`re.all`).
     pub fn mk_regexp_all(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_regexp_all(self.ptr_mut()) })
+        Term::from_raw(unsafe { mk_regexp_all(self.ptr_mut()) })
     }
     /// Create the regular expression that matches any single character.
     pub fn mk_regexp_allchar(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_regexp_allchar(self.ptr_mut()) })
+        Term::from_raw(unsafe { mk_regexp_allchar(self.ptr_mut()) })
     }
     /// Create the regular expression that matches nothing (`re.none`).
     pub fn mk_regexp_none(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_regexp_none(self.ptr_mut()) })
+        Term::from_raw(unsafe { mk_regexp_none(self.ptr_mut()) })
     }
 
     /// Create an empty set of the given sort.
     pub fn mk_empty_set(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_empty_set(self.ptr_mut(), sort.inner) })
+        Term::from_raw(unsafe { mk_empty_set(self.ptr_mut(), sort.inner) })
     }
 
     /// Create an empty bag of the given sort.
     pub fn mk_empty_bag(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_empty_bag(self.ptr_mut(), sort.inner) })
+        Term::from_raw(unsafe { mk_empty_bag(self.ptr_mut(), sort.inner) })
     }
 
     /// Create the separation logic empty heap constraint.
     pub fn mk_sep_emp(&self) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_sep_emp(self.ptr_mut()) })
+        Term::from_raw(unsafe { mk_sep_emp(self.ptr_mut()) })
     }
 
     /// Create the separation logic nil term of the given sort.
     pub fn mk_sep_nil(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_sep_nil(self.ptr_mut(), sort.inner) })
+        Term::from_raw(unsafe { mk_sep_nil(self.ptr_mut(), sort.inner) })
     }
 
     /// Create a string constant. If `use_esc_seq` is true, process escape sequences.
     pub fn mk_string(&self, s: &str, use_esc_seq: bool) -> Term {
         let c = CString::new(s).unwrap();
-        Term::from_raw(unsafe { cvc5_mk_string(self.ptr_mut(), c.as_ptr(), use_esc_seq) })
+        Term::from_raw(unsafe { mk_string(self.ptr_mut(), c.as_ptr(), use_esc_seq) })
     }
 
     /// Create an empty sequence of the given element sort.
     pub fn mk_empty_sequence(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_empty_sequence(self.ptr_mut(), sort.inner) })
+        Term::from_raw(unsafe { mk_empty_sequence(self.ptr_mut(), sort.inner) })
     }
 
     /// Create the universe set of the given sort.
     pub fn mk_universe_set(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_universe_set(self.ptr_mut(), sort.inner) })
+        Term::from_raw(unsafe { mk_universe_set(self.ptr_mut(), sort.inner) })
     }
 
     /// Create a bit-vector constant of the given size and value.
     pub fn mk_bv(&self, size: u32, val: u64) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_bv_uint64(self.ptr_mut(), size, val) })
+        Term::from_raw(unsafe { mk_bv_uint64(self.ptr_mut(), size, val) })
     }
 
     /// Create a bit-vector constant from a string in the given base (2, 10, or 16).
     pub fn mk_bv_from_str(&self, size: u32, s: &str, base: u32) -> Term {
         let c = CString::new(s).unwrap();
-        Term::from_raw(unsafe { cvc5_mk_bv(self.ptr_mut(), size, c.as_ptr(), base) })
+        Term::from_raw(unsafe { mk_bv(self.ptr_mut(), size, c.as_ptr(), base) })
     }
 
     /// Create a finite field element from a string value in the given base.
     pub fn mk_ff_elem(&self, value: &str, sort: Sort, base: u32) -> Term {
         let c = CString::new(value).unwrap();
-        Term::from_raw(unsafe { cvc5_mk_ff_elem(self.ptr_mut(), c.as_ptr(), sort.inner, base) })
+        Term::from_raw(unsafe { mk_ff_elem(self.ptr_mut(), c.as_ptr(), sort.inner, base) })
     }
 
     /// Create a constant array where every element is `val`.
     pub fn mk_const_array(&self, sort: Sort, val: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_const_array(self.ptr_mut(), sort.inner, val.inner) })
+        Term::from_raw(unsafe { mk_const_array(self.ptr_mut(), sort.inner, val.inner) })
     }
 
     /// Create a positive infinity floating-point constant.
     pub fn mk_fp_pos_inf(&self, exp: u32, sig: u32) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_fp_pos_inf(self.ptr_mut(), exp, sig) })
+        Term::from_raw(unsafe { mk_fp_pos_inf(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a negative infinity floating-point constant.
     pub fn mk_fp_neg_inf(&self, exp: u32, sig: u32) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_fp_neg_inf(self.ptr_mut(), exp, sig) })
+        Term::from_raw(unsafe { mk_fp_neg_inf(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a NaN floating-point constant.
     pub fn mk_fp_nan(&self, exp: u32, sig: u32) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_fp_nan(self.ptr_mut(), exp, sig) })
+        Term::from_raw(unsafe { mk_fp_nan(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a positive zero floating-point constant.
     pub fn mk_fp_pos_zero(&self, exp: u32, sig: u32) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_fp_pos_zero(self.ptr_mut(), exp, sig) })
+        Term::from_raw(unsafe { mk_fp_pos_zero(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a negative zero floating-point constant.
     pub fn mk_fp_neg_zero(&self, exp: u32, sig: u32) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_fp_neg_zero(self.ptr_mut(), exp, sig) })
+        Term::from_raw(unsafe { mk_fp_neg_zero(self.ptr_mut(), exp, sig) })
     }
 
     /// Create a rounding mode constant.
-    pub fn mk_rm(&self, rm: Cvc5RoundingMode) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_rm(self.ptr_mut(), rm) })
+    pub fn mk_rm(&self, rm: cvc5_sys::RoundingMode) -> Term {
+        Term::from_raw(unsafe { mk_rm(self.ptr_mut(), rm) })
     }
 
     /// Create a floating-point constant from a bit-vector value.
     pub fn mk_fp(&self, exp: u32, sig: u32, val: Term) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_fp(self.ptr_mut(), exp, sig, val.inner) })
+        Term::from_raw(unsafe { mk_fp(self.ptr_mut(), exp, sig, val.inner) })
     }
 
     /// Create a floating-point constant from IEEE 754 sign, exponent, and significand bit-vectors.
     pub fn mk_fp_from_ieee(&self, sign: Term, exp: Term, sig: Term) -> Term {
-        Term::from_raw(unsafe {
-            cvc5_mk_fp_from_ieee(self.ptr_mut(), sign.inner, exp.inner, sig.inner)
-        })
+        Term::from_raw(unsafe { mk_fp_from_ieee(self.ptr_mut(), sign.inner, exp.inner, sig.inner) })
     }
 
     /// Create a cardinality constraint on the given sort.
     pub fn mk_cardinality_constraint(&self, sort: Sort, upper_bound: u32) -> Term {
         Term::from_raw(unsafe {
-            cvc5_mk_cardinality_constraint(self.ptr_mut(), sort.inner, upper_bound)
+            mk_cardinality_constraint(self.ptr_mut(), sort.inner, upper_bound)
         })
     }
 
@@ -437,23 +433,23 @@ impl TermManager {
     /// Create a named constant (free variable) of the given sort.
     pub fn mk_const(&self, sort: Sort, name: &str) -> Term {
         let c = CString::new(name).unwrap();
-        Term::from_raw(unsafe { cvc5_mk_const(self.ptr_mut(), sort.inner, c.as_ptr()) })
+        Term::from_raw(unsafe { mk_const(self.ptr_mut(), sort.inner, c.as_ptr()) })
     }
 
     /// Create an anonymous constant (free variable) of the given sort.
     pub fn mk_anonymous_const(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_const(self.ptr_mut(), sort.inner, std::ptr::null()) })
+        Term::from_raw(unsafe { mk_const(self.ptr_mut(), sort.inner, std::ptr::null()) })
     }
 
     /// Create a bound variable of the given sort.
     pub fn mk_var(&self, sort: Sort, name: &str) -> Term {
         let c = CString::new(name).unwrap();
-        Term::from_raw(unsafe { cvc5_mk_var(self.ptr_mut(), sort.inner, c.as_ptr()) })
+        Term::from_raw(unsafe { mk_var(self.ptr_mut(), sort.inner, c.as_ptr()) })
     }
 
     /// Create an anonymous bound variable of the given sort.
     pub fn mk_anonymous_var(&self, sort: Sort) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_var(self.ptr_mut(), sort.inner, std::ptr::null()) })
+        Term::from_raw(unsafe { mk_var(self.ptr_mut(), sort.inner, std::ptr::null()) })
     }
 
     // ── Datatype declarations ──────────────────────────────────────
@@ -461,15 +457,13 @@ impl TermManager {
     /// Create a datatype constructor declaration with the given name.
     pub fn mk_dt_cons_decl(&self, name: &str) -> DatatypeConstructorDecl {
         let c = CString::new(name).unwrap();
-        DatatypeConstructorDecl::from_raw(unsafe {
-            cvc5_mk_dt_cons_decl(self.ptr_mut(), c.as_ptr())
-        })
+        DatatypeConstructorDecl::from_raw(unsafe { mk_dt_cons_decl(self.ptr_mut(), c.as_ptr()) })
     }
 
     /// Create a datatype declaration. Set `is_codt` to `true` for codatatypes.
     pub fn mk_dt_decl(&self, name: &str, is_codt: bool) -> DatatypeDecl {
         let c = CString::new(name).unwrap();
-        DatatypeDecl::from_raw(unsafe { cvc5_mk_dt_decl(self.ptr_mut(), c.as_ptr(), is_codt) })
+        DatatypeDecl::from_raw(unsafe { mk_dt_decl(self.ptr_mut(), c.as_ptr(), is_codt) })
     }
 
     /// Create a parametric datatype declaration with sort parameters.
@@ -480,36 +474,30 @@ impl TermManager {
         is_codt: bool,
     ) -> DatatypeDecl {
         let c = CString::new(name).unwrap();
-        let raw: Vec<Cvc5Sort> = params.iter().map(|s| s.inner).collect();
+        let raw: Vec<cvc5_sys::Sort> = params.iter().map(|s| s.inner).collect();
         DatatypeDecl::from_raw(unsafe {
-            cvc5_mk_dt_decl_with_params(
-                self.ptr_mut(),
-                c.as_ptr(),
-                raw.len(),
-                raw.as_ptr(),
-                is_codt,
-            )
+            mk_dt_decl_with_params(self.ptr_mut(), c.as_ptr(), raw.len(), raw.as_ptr(), is_codt)
         })
     }
 
     /// Create a string constant from a null-terminated `wchar_t` array.
     pub fn mk_string_from_wchar(&self, s: &[wchar_t]) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_string_from_wchar(self.ptr_mut(), s.as_ptr()) })
+        Term::from_raw(unsafe { mk_string_from_wchar(self.ptr_mut(), s.as_ptr()) })
     }
 
     /// Create a string constant from a null-terminated `char32_t` array.
     pub fn mk_string_from_char32(&self, s: &[char32_t]) -> Term {
-        Term::from_raw(unsafe { cvc5_mk_string_from_char32(self.ptr_mut(), s.as_ptr()) })
+        Term::from_raw(unsafe { mk_string_from_char32(self.ptr_mut(), s.as_ptr()) })
     }
 
     /// Get the term manager statistics.
     pub fn get_statistics(&self) -> Statistics {
-        Statistics::from_raw(unsafe { cvc5_term_manager_get_statistics(self.ptr()) })
+        Statistics::from_raw(unsafe { term_manager_get_statistics(self.ptr()) })
     }
 
     /// Print term manager statistics to the given file descriptor (async-signal-safe).
     pub fn print_stats_safe(&self, fd: i32) {
-        unsafe { cvc5_term_manager_print_stats_safe(self.ptr(), fd) }
+        unsafe { term_manager_print_stats_safe(self.ptr(), fd) }
     }
 }
 
@@ -522,7 +510,7 @@ impl Default for TermManager {
 impl Drop for TermManager {
     fn drop(&mut self) {
         if Rc::strong_count(&self.inner) == 1 {
-            unsafe { cvc5_term_manager_delete(self.ptr()) }
+            unsafe { term_manager_delete(self.ptr()) }
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,7 @@
-use cvc5::{Kind, Solver, TermManager};
+use cvc5::{
+    BlockModelsMode, Kind, LearnedLitType, ProofComponent, ProofFormat, RoundingMode, SkolemId,
+    Solver, SortKind, TermManager,
+};
 
 /// Helper: create a TermManager + Solver pair with common setup.
 macro_rules! setup {
@@ -418,7 +421,7 @@ fn proof_basic() {
     solver.assert_formula(not_a);
     assert!(solver.check_sat().is_unsat());
 
-    let proofs = solver.get_proof(cvc5_sys::Cvc5ProofComponent::Full);
+    let proofs = solver.get_proof(ProofComponent::Full);
     assert!(!proofs.is_empty());
 
     let p = &proofs[0];
@@ -836,15 +839,9 @@ fn sort_ord() {
 #[test]
 fn sort_kind() {
     let tm = TermManager::new();
-    assert_eq!(
-        tm.boolean_sort().kind(),
-        cvc5_sys::Cvc5SortKind::BooleanSort
-    );
-    assert_eq!(
-        tm.integer_sort().kind(),
-        cvc5_sys::Cvc5SortKind::IntegerSort
-    );
-    assert_eq!(tm.real_sort().kind(), cvc5_sys::Cvc5SortKind::RealSort);
+    assert_eq!(tm.boolean_sort().kind(), SortKind::BooleanSort);
+    assert_eq!(tm.integer_sort().kind(), SortKind::IntegerSort);
+    assert_eq!(tm.real_sort().kind(), SortKind::RealSort);
 }
 
 // ── Sort: substitute ───────────────────────────────────────────────
@@ -888,9 +885,9 @@ fn sort_record() {
 #[test]
 fn sort_abstract() {
     let tm = TermManager::new();
-    let abs = tm.mk_abstract_sort(cvc5_sys::Cvc5SortKind::BitvectorSort);
+    let abs = tm.mk_abstract_sort(SortKind::BitvectorSort);
     assert!(abs.is_abstract());
-    assert_eq!(abs.abstract_kind(), cvc5_sys::Cvc5SortKind::BitvectorSort);
+    assert_eq!(abs.abstract_kind(), SortKind::BitvectorSort);
 }
 
 // ── Sort: Clone trait ──────────────────────────────────────────────
@@ -1593,12 +1590,9 @@ fn term_fp_value() {
 #[test]
 fn term_rm_value() {
     let tm = TermManager::new();
-    let rne = tm.mk_rm(cvc5_sys::Cvc5RoundingMode::RoundNearestTiesToEven);
+    let rne = tm.mk_rm(RoundingMode::RoundNearestTiesToEven);
     assert!(rne.is_rm_value());
-    assert_eq!(
-        rne.rm_value(),
-        cvc5_sys::Cvc5RoundingMode::RoundNearestTiesToEven
-    );
+    assert_eq!(rne.rm_value(), RoundingMode::RoundNearestTiesToEven);
 }
 
 // ── Term: const array ──────────────────────────────────────────────
@@ -1818,7 +1812,7 @@ fn term_pi() {
 #[test]
 fn term_skolem() {
     let tm = TermManager::new();
-    let id = cvc5_sys::Cvc5SkolemId::Purify;
+    let id = SkolemId::Purify;
     let n = tm.get_num_idxs_for_skolem_id(id);
     assert!(n > 0);
 
@@ -2003,7 +1997,7 @@ fn tm_mk_bv_from_str_bases() {
 
 #[test]
 fn tm_all_rounding_modes() {
-    use cvc5_sys::Cvc5RoundingMode::*;
+    use RoundingMode::*;
     let tm = TermManager::new();
     for rm in [
         RoundNearestTiesToEven,
@@ -2241,7 +2235,7 @@ fn solver_block_model() {
     solver.assert_formula(tm.mk_term(Kind::Leq, &[x.clone(), ten]));
     assert!(solver.check_sat().is_sat());
     let v1 = solver.get_value(x.clone()).int32_value();
-    solver.block_model(cvc5_sys::Cvc5BlockModelsMode::Values);
+    solver.block_model(BlockModelsMode::Values);
     assert!(solver.check_sat().is_sat());
     let v2 = solver.get_value(x).int32_value();
     assert_ne!(v1, v2);
@@ -2345,11 +2339,11 @@ fn solver_proof_to_string() {
     solver.assert_formula(not_a.clone());
     assert!(solver.check_sat().is_unsat());
 
-    let proofs = solver.get_proof(cvc5_sys::Cvc5ProofComponent::Full);
+    let proofs = solver.get_proof(ProofComponent::Full);
     assert!(!proofs.is_empty());
     let s = solver.proof_to_string(
         proofs[0].copy(),
-        cvc5_sys::Cvc5ProofFormat::Default,
+        ProofFormat::Default,
         &[a, not_a],
         &["a", "not_a"],
     );
@@ -2371,7 +2365,7 @@ fn solver_get_learned_literals() {
     let zero = tm.mk_integer(0);
     solver.assert_formula(tm.mk_term(Kind::Gt, &[x, zero]));
     assert!(solver.check_sat().is_sat());
-    let lits = solver.get_learned_literals(cvc5_sys::Cvc5LearnedLitType::Input);
+    let lits = solver.get_learned_literals(LearnedLitType::Input);
     // returned vec may be empty but should not panic; verify it's a valid vec
     for lit in &lits {
         assert!(lit.sort().is_boolean());


### PR DESCRIPTION
Resolves #45

Replaced (on source code, not prebuilt) using

```sh
sed -i 's/cvc5_//' *.rs
sed -i 's/use sys/use cvc5_sys/' *.rs
sed -i 's/Cvc5//' *.rs
```