### PR TITLE
feat: Re-export `OptionInfoCategory` and `OptionInfoKind`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@ mod term_manager;
 
 // Reexport enums
 pub use cvc5_sys::{
-    BlockModelsMode, FindSynthTarget, InputLanguage, Kind, LearnedLitType, OptionCategory,
-    OptionInfoKind, Plugin, ProofComponent, ProofFormat, ProofRewriteRule, ProofRule,
-    RoundingMode, SkolemId, SortKind, UnknownExplanation,
+    BlockModelsMode, FindSynthTarget, InputLanguage, Kind, LearnedLitType, OptionCategory, Plugin,
+    ProofComponent, ProofFormat, ProofRewriteRule, ProofRule, RoundingMode, SkolemId, SortKind,
+    UnknownExplanation,
 };
 
 pub use datatype::{
@@ -55,7 +55,7 @@ pub use grammar::Grammar;
 pub use op::Op;
 pub use proof::Proof;
 pub use result::Result;
-pub use solver::{OptionInfo, Solver};
+pub use solver::{OptionInfo, OptionInfoKind, Solver};
 pub use sort::Sort;
 pub use statistics::{Stat, Statistics};
 pub use synth_result::SynthResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,20 +41,12 @@ mod synth_result;
 mod term;
 mod term_manager;
 
-pub use cvc5_sys::BlockModelsMode;
-pub use cvc5_sys::FindSynthTarget;
-pub use cvc5_sys::Kind;
-pub use cvc5_sys::LearnedLitType;
-pub use cvc5_sys::OptionInfo;
-pub use cvc5_sys::Plugin;
-pub use cvc5_sys::ProofComponent;
-pub use cvc5_sys::ProofFormat;
-pub use cvc5_sys::ProofRewriteRule;
-pub use cvc5_sys::ProofRule;
-pub use cvc5_sys::RoundingMode;
-pub use cvc5_sys::SkolemId;
-pub use cvc5_sys::SortKind;
-pub use cvc5_sys::UnknownExplanation;
+// Reexport enums
+pub use cvc5_sys::{
+    BlockModelsMode, FindSynthTarget, InputLanguage, Kind, LearnedLitType, OptionCategory,
+    OptionInfo, OptionInfoKind, Plugin, ProofComponent, ProofFormat, ProofRewriteRule, ProofRule,
+    RoundingMode, SkolemId, SortKind, UnknownExplanation,
+};
 
 pub use datatype::{
     Datatype, DatatypeConstructor, DatatypeConstructorDecl, DatatypeDecl, DatatypeSelector,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod term_manager;
 // Reexport enums
 pub use cvc5_sys::{
     BlockModelsMode, FindSynthTarget, InputLanguage, Kind, LearnedLitType, OptionCategory,
-    OptionInfo, OptionInfoKind, Plugin, ProofComponent, ProofFormat, ProofRewriteRule, ProofRule,
+    OptionInfoKind, Plugin, ProofComponent, ProofFormat, ProofRewriteRule, ProofRule,
     RoundingMode, SkolemId, SortKind, UnknownExplanation,
 };
 
@@ -55,7 +55,7 @@ pub use grammar::Grammar;
 pub use op::Op;
 pub use proof::Proof;
 pub use result::Result;
-pub use solver::Solver;
+pub use solver::{OptionInfo, Solver};
 pub use sort::Sort;
 pub use statistics::{Stat, Statistics};
 pub use synth_result::SynthResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,8 @@ mod term_manager;
 
 // Reexport enums
 pub use cvc5_sys::{
-    BlockModelsMode, FindSynthTarget, InputLanguage, Kind, LearnedLitType, OptionCategory, Plugin,
-    ProofComponent, ProofFormat, ProofRewriteRule, ProofRule, RoundingMode, SkolemId, SortKind,
-    UnknownExplanation,
+    BlockModelsMode, FindSynthTarget, Kind, LearnedLitType, OptionCategory, Plugin, ProofComponent,
+    ProofFormat, ProofRewriteRule, ProofRule, RoundingMode, SkolemId, SortKind, UnknownExplanation,
 };
 
 pub use datatype::{

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -125,8 +125,7 @@ impl OptionInfo {
         self.0.category
     }
     pub fn name(&self) -> impl AsRef<str> {
-        let s = unsafe { std::ffi::CStr::from_ptr(self.0.name).to_string_lossy() };
-        s
+        unsafe { std::ffi::CStr::from_ptr(self.0.name).to_string_lossy() }
     }
     pub fn is_set_by_user(&self) -> bool {
         self.0.is_set_by_user

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,11 +1,56 @@
 use cvc5_sys::*;
 use std::ffi::CString;
+use std::fmt;
 use std::marker::PhantomData;
 
 use crate::{
     DatatypeConstructorDecl, Grammar, Proof, Result, Sort, Statistics, SynthResult, Term,
     TermManager,
 };
+
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct OptionInfo(cvc5_sys::OptionInfo);
+
+impl OptionInfo {
+    pub fn kind(&self) -> OptionInfoKind {
+        self.0.kind
+    }
+    pub fn category(&self) -> OptionCategory {
+        self.0.category
+    }
+    pub fn name(&self) -> impl AsRef<str> {
+        let s = unsafe { std::ffi::CStr::from_ptr(self.0.name).to_string_lossy() };
+        s
+    }
+    pub fn is_set_by_user(&self) -> bool {
+        self.0.is_set_by_user
+    }
+    pub fn aliases(&self) -> Vec<String> {
+        (0..self.0.num_aliases)
+            .map(|i| {
+                let p = unsafe { *self.0.aliases.add(i) };
+                unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }.into_owned()
+            })
+            .collect()
+    }
+    pub fn no_supports(&self) -> Vec<String> {
+        (0..self.0.num_no_supports)
+            .map(|i| {
+                let p = unsafe { *self.0.no_supports.add(i) };
+                unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }.into_owned()
+            })
+            .collect()
+    }
+}
+
+impl fmt::Display for OptionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s =
+            unsafe { std::ffi::CStr::from_ptr(option_info_to_string(&self.0)).to_string_lossy() };
+        write!(f, "{}", s)
+    }
+}
 
 /// A cvc5 solver instance.
 ///
@@ -734,20 +779,11 @@ impl<'tm> Solver<'tm> {
     }
 
     /// Get detailed information about a solver option.
-    pub fn get_option_info(&self, option: &str) -> cvc5_sys::OptionInfo {
+    pub fn get_option_info(&self, option: &str) -> OptionInfo {
         let c = CString::new(option).unwrap();
         let mut info: cvc5_sys::OptionInfo = unsafe { std::mem::zeroed() };
         unsafe { get_option_info(self.inner, c.as_ptr(), &mut info) };
-        info
-    }
-
-    /// Convert option info to a human-readable string.
-    pub fn option_info_to_string(info: &cvc5_sys::OptionInfo) -> String {
-        unsafe {
-            std::ffi::CStr::from_ptr(option_info_to_string(info))
-                .to_string_lossy()
-                .into_owned()
-        }
+        OptionInfo(info)
     }
 
     // ── Plugin ─────────────────────────────────────────────────────

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -47,74 +47,76 @@ pub enum OptionInfoKind<'a> {
 }
 
 #[derive(Copy, Clone)]
-#[repr(transparent)]
-pub struct OptionInfo(cvc5_sys::OptionInfo);
+pub struct OptionInfo<'a> {
+    inner: cvc5_sys::OptionInfo,
+    _phantom: PhantomData<&'a ()>,
+}
 
-impl OptionInfo {
+impl OptionInfo<'_> {
     pub fn kind(&self) -> OptionInfoKind<'_> {
         use cvc5_sys::OptionInfoKind as K;
-        match self.0.kind {
+        match self.inner.kind {
             K::Void => OptionInfoKind::Void,
             K::Bool => OptionInfoKind::Bool {
-                default: self.0.info_bool.dflt,
-                current: self.0.info_bool.cur,
+                default: self.inner.info_bool.dflt,
+                current: self.inner.info_bool.cur,
             },
             K::Str => OptionInfoKind::String {
-                default: unsafe { std::ffi::CStr::from_ptr(self.0.info_str.dflt).to_str() }
+                default: unsafe { std::ffi::CStr::from_ptr(self.inner.info_str.dflt).to_str() }
                     .expect(ERROR_NOT_UTF8),
-                current: unsafe { std::ffi::CStr::from_ptr(self.0.info_str.cur).to_str() }
+                current: unsafe { std::ffi::CStr::from_ptr(self.inner.info_str.cur).to_str() }
                     .expect(ERROR_NOT_UTF8),
             },
             K::Int64 => OptionInfoKind::Int64 {
-                default: self.0.info_int.dflt,
-                current: self.0.info_int.cur,
-                min: if self.0.info_int.has_min {
-                    Some(self.0.info_int.min)
+                default: self.inner.info_int.dflt,
+                current: self.inner.info_int.cur,
+                min: if self.inner.info_int.has_min {
+                    Some(self.inner.info_int.min)
                 } else {
                     None
                 },
-                max: if self.0.info_int.has_max {
-                    Some(self.0.info_int.max)
+                max: if self.inner.info_int.has_max {
+                    Some(self.inner.info_int.max)
                 } else {
                     None
                 },
             },
             K::Uint64 => OptionInfoKind::UInt64 {
-                default: self.0.info_uint.dflt,
-                current: self.0.info_uint.cur,
-                min: if self.0.info_uint.has_min {
-                    Some(self.0.info_uint.min)
+                default: self.inner.info_uint.dflt,
+                current: self.inner.info_uint.cur,
+                min: if self.inner.info_uint.has_min {
+                    Some(self.inner.info_uint.min)
                 } else {
                     None
                 },
-                max: if self.0.info_uint.has_max {
-                    Some(self.0.info_uint.max)
+                max: if self.inner.info_uint.has_max {
+                    Some(self.inner.info_uint.max)
                 } else {
                     None
                 },
             },
             K::Double => OptionInfoKind::Double {
-                default: self.0.info_double.dflt,
-                current: self.0.info_double.cur,
-                min: if self.0.info_double.has_min {
-                    Some(self.0.info_double.min)
+                default: self.inner.info_double.dflt,
+                current: self.inner.info_double.cur,
+                min: if self.inner.info_double.has_min {
+                    Some(self.inner.info_double.min)
                 } else {
                     None
                 },
-                max: if self.0.info_double.has_max {
-                    Some(self.0.info_double.max)
+                max: if self.inner.info_double.has_max {
+                    Some(self.inner.info_double.max)
                 } else {
                     None
                 },
             },
             K::Modes => OptionInfoKind::Mode {
-                default: unsafe { std::ffi::CStr::from_ptr(self.0.info_mode.dflt).to_str() }
+                default: unsafe { std::ffi::CStr::from_ptr(self.inner.info_mode.dflt).to_str() }
                     .expect(ERROR_NOT_UTF8),
-                current: unsafe { std::ffi::CStr::from_ptr(self.0.info_mode.cur).to_str() }
+                current: unsafe { std::ffi::CStr::from_ptr(self.inner.info_mode.cur).to_str() }
                     .expect(ERROR_NOT_UTF8),
-                modes: (0..self.0.info_mode.num_modes)
+                modes: (0..self.inner.info_mode.num_modes)
                     .map(|i| {
-                        let p = unsafe { *self.0.info_mode.modes.add(i) };
+                        let p = unsafe { *self.inner.info_mode.modes.add(i) };
                         unsafe { std::ffi::CStr::from_ptr(p).to_str() }.expect(ERROR_NOT_UTF8)
                     })
                     .collect(),
@@ -122,36 +124,37 @@ impl OptionInfo {
         }
     }
     pub fn category(&self) -> OptionCategory {
-        self.0.category
+        self.inner.category
     }
     pub fn name(&self) -> impl AsRef<str> {
-        unsafe { std::ffi::CStr::from_ptr(self.0.name).to_string_lossy() }
+        unsafe { std::ffi::CStr::from_ptr(self.inner.name).to_string_lossy() }
     }
     pub fn is_set_by_user(&self) -> bool {
-        self.0.is_set_by_user
+        self.inner.is_set_by_user
     }
     pub fn aliases(&self) -> Vec<impl AsRef<str>> {
-        (0..self.0.num_aliases)
+        (0..self.inner.num_aliases)
             .map(|i| {
-                let p = unsafe { *self.0.aliases.add(i) };
+                let p = unsafe { *self.inner.aliases.add(i) };
                 unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }
             })
             .collect()
     }
     pub fn no_supports(&self) -> Vec<impl AsRef<str>> {
-        (0..self.0.num_no_supports)
+        (0..self.inner.num_no_supports)
             .map(|i| {
-                let p = unsafe { *self.0.no_supports.add(i) };
+                let p = unsafe { *self.inner.no_supports.add(i) };
                 unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }
             })
             .collect()
     }
 }
 
-impl fmt::Display for OptionInfo {
+impl fmt::Display for OptionInfo<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s =
-            unsafe { std::ffi::CStr::from_ptr(option_info_to_string(&self.0)).to_string_lossy() };
+        let s = unsafe {
+            std::ffi::CStr::from_ptr(option_info_to_string(&self.inner)).to_string_lossy()
+        };
         write!(f, "{}", s)
     }
 }
@@ -882,12 +885,17 @@ impl<'tm> Solver<'tm> {
         Statistics::from_raw(unsafe { get_statistics(self.inner) })
     }
 
-    /// Get detailed information about a solver option.
-    pub fn get_option_info(&self, option: &str) -> OptionInfo {
+    /**
+    Get detailed information about a solver option.
+     */
+    pub fn get_option_info(&mut self, option: &str) -> OptionInfo<'_> {
         let c = CString::new(option).unwrap();
         let mut info: cvc5_sys::OptionInfo = unsafe { std::mem::zeroed() };
         unsafe { get_option_info(self.inner, c.as_ptr(), &mut info) };
-        OptionInfo(info)
+        OptionInfo {
+            inner: info,
+            _phantom: PhantomData,
+        }
     }
 
     // ── Plugin ─────────────────────────────────────────────────────

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -8,13 +8,118 @@ use crate::{
     TermManager,
 };
 
+const ERROR_NOT_UTF8: &str = "Not UTF-8";
+
+#[derive(Clone)]
+pub enum OptionInfoKind<'a> {
+    Void,
+    Bool {
+        default: bool,
+        current: bool,
+    },
+    String {
+        default: &'a str,
+        current: &'a str,
+    },
+    Int64 {
+        default: i64,
+        current: i64,
+        min: Option<i64>,
+        max: Option<i64>,
+    },
+    UInt64 {
+        default: u64,
+        current: u64,
+        min: Option<u64>,
+        max: Option<u64>,
+    },
+    Double {
+        default: f64,
+        current: f64,
+        min: Option<f64>,
+        max: Option<f64>,
+    },
+    Mode {
+        default: &'a str,
+        current: &'a str,
+        modes: Vec<&'a str>,
+    },
+}
+
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct OptionInfo(cvc5_sys::OptionInfo);
 
 impl OptionInfo {
-    pub fn kind(&self) -> OptionInfoKind {
-        self.0.kind
+    pub fn kind(&self) -> OptionInfoKind<'_> {
+        use cvc5_sys::OptionInfoKind as K;
+        match self.0.kind {
+            K::Void => OptionInfoKind::Void,
+            K::Bool => OptionInfoKind::Bool {
+                default: self.0.info_bool.dflt,
+                current: self.0.info_bool.cur,
+            },
+            K::Str => OptionInfoKind::String {
+                default: unsafe { std::ffi::CStr::from_ptr(self.0.info_str.dflt).to_str() }
+                    .expect(ERROR_NOT_UTF8),
+                current: unsafe { std::ffi::CStr::from_ptr(self.0.info_str.cur).to_str() }
+                    .expect(ERROR_NOT_UTF8),
+            },
+            K::Int64 => OptionInfoKind::Int64 {
+                default: self.0.info_int.dflt,
+                current: self.0.info_int.cur,
+                min: if self.0.info_int.has_min {
+                    Some(self.0.info_int.min)
+                } else {
+                    None
+                },
+                max: if self.0.info_int.has_max {
+                    Some(self.0.info_int.max)
+                } else {
+                    None
+                },
+            },
+            K::Uint64 => OptionInfoKind::UInt64 {
+                default: self.0.info_uint.dflt,
+                current: self.0.info_uint.cur,
+                min: if self.0.info_uint.has_min {
+                    Some(self.0.info_uint.min)
+                } else {
+                    None
+                },
+                max: if self.0.info_uint.has_max {
+                    Some(self.0.info_uint.max)
+                } else {
+                    None
+                },
+            },
+            K::Double => OptionInfoKind::Double {
+                default: self.0.info_double.dflt,
+                current: self.0.info_double.cur,
+                min: if self.0.info_double.has_min {
+                    Some(self.0.info_double.min)
+                } else {
+                    None
+                },
+                max: if self.0.info_double.has_max {
+                    Some(self.0.info_double.max)
+                } else {
+                    None
+                },
+            },
+            K::Modes => OptionInfoKind::Mode {
+                default: unsafe { std::ffi::CStr::from_ptr(self.0.info_mode.dflt).to_str() }
+                    .expect(ERROR_NOT_UTF8),
+                current: unsafe { std::ffi::CStr::from_ptr(self.0.info_mode.cur).to_str() }
+                    .expect(ERROR_NOT_UTF8),
+                modes: (0..self.0.info_mode.num_modes)
+                    .map(|i| {
+                        let p = unsafe { *self.0.info_mode.modes.add(i) };
+                        unsafe { std::ffi::CStr::from_ptr(p).to_str() }.expect(ERROR_NOT_UTF8)
+                    })
+                    .collect(),
+            },
+        }
     }
     pub fn category(&self) -> OptionCategory {
         self.0.category
@@ -26,19 +131,19 @@ impl OptionInfo {
     pub fn is_set_by_user(&self) -> bool {
         self.0.is_set_by_user
     }
-    pub fn aliases(&self) -> Vec<String> {
+    pub fn aliases(&self) -> Vec<impl AsRef<str>> {
         (0..self.0.num_aliases)
             .map(|i| {
                 let p = unsafe { *self.0.aliases.add(i) };
-                unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }.into_owned()
+                unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }
             })
             .collect()
     }
-    pub fn no_supports(&self) -> Vec<String> {
+    pub fn no_supports(&self) -> Vec<impl AsRef<str>> {
         (0..self.0.num_no_supports)
             .map(|i| {
                 let p = unsafe { *self.0.no_supports.add(i) };
-                unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }.into_owned()
+                unsafe { std::ffi::CStr::from_ptr(p).to_string_lossy() }
             })
             .collect()
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2045,8 +2045,10 @@ fn solver_option_info() {
     let tm = TermManager::new();
     let solver = Solver::new(&tm);
     let info = solver.get_option_info("produce-models");
-    let s = Solver::option_info_to_string(&info);
-    assert!(!s.is_empty());
+    assert_eq!(
+        info.to_string(),
+        "OptionInfo{ produce-models | bool | false | default false }"
+    );
 }
 
 // ── simplify ───────────────────────────────────────────────────────

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2043,7 +2043,7 @@ fn solver_get_option_names() {
 #[test]
 fn solver_option_info() {
     let tm = TermManager::new();
-    let solver = Solver::new(&tm);
+    let mut solver = Solver::new(&tm);
     let info = solver.get_option_info("produce-models");
     assert_eq!(
         info.to_string(),


### PR DESCRIPTION
This reexports 2 enums and implements a wrapper for `OptionInfo` so the user does not have to deal with raw objects.

Since acquiring a new `OptionInfo` invalidates the previous one, `get_option_info` takes a mutable reference of the solver as lifetime bound to the `OptionInfo`. Technically speaking this would also block all other `&mut self` operations on the solver, but Rust can't split borrowings so the only solution involving no runtime overhead is this one.