### PR TITLE
adjust the build script to avoid building cvc5 for dynamic linking

### DIFF
--- a/.github/actions/setup-cvc5/action.yml
+++ b/.github/actions/setup-cvc5/action.yml
@@ -58,5 +58,4 @@ runs:
           cd build-dynamic
           make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
           make install
-          cp deps/lib/libcadical.a deps/lib/libgmp* install/lib
         fi

--- a/.github/actions/setup-cvc5/action.yml
+++ b/.github/actions/setup-cvc5/action.yml
@@ -1,0 +1,62 @@
+name: Setup cvc5
+description: Build and cache cvc5 (static, and optionally dynamic)
+
+inputs:
+  build-dynamic:
+    description: Also build the dynamic-linking variant of cvc5
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Install build dependencies (Ubuntu)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential cmake
+
+    - name: Install build dependencies (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install cmake
+
+    - name: Cache cvc5 build (static)
+      uses: actions/cache@v4
+      with:
+        path: cvc5-sys/cvc5/build
+        key: ${{ runner.os }}-cvc5-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
+        restore-keys: ${{ runner.os }}-cvc5-
+
+    - name: Build cvc5 (static)
+      shell: bash
+      run: |
+        cd cvc5-sys/cvc5
+        if [ ! -f build/install/lib/libcvc5.a ]; then
+          ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
+          cd build
+          make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+          make install
+        fi
+
+    - name: Cache cvc5 build (dynamic)
+      if: inputs.build-dynamic == 'true'
+      uses: actions/cache@v4
+      with:
+        path: cvc5-sys/cvc5/build-dynamic
+        key: ${{ runner.os }}-cvc5-dynamic-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
+        restore-keys: ${{ runner.os }}-cvc5-dynamic
+
+    - name: Build cvc5 (dynamic)
+      if: inputs.build-dynamic == 'true'
+      shell: bash
+      run: |
+        cd cvc5-sys/cvc5
+        if [ ! -f build-dynamic/install/lib/libcvc5.so -a ! -f build-dynamic/install/lib/libcvc5.dylib ]; then
+          ./configure.sh --name=build-dynamic --auto-download --prefix=$(pwd)/build-dynamic/install -DBUILD_GMP=1
+          cd build-dynamic
+          make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+          make install
+          cp deps/lib/libcadical.a deps/lib/libgmp* install/lib
+        fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
           key: ${{ runner.os }}-cvc5-dynamic-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
           restore-keys: ${{ runner.os }}-cvc5-dynamic
 
-      - name: Build cvc5
+      - name: Build cvc5 (static linking)
         run: |
           cd cvc5-sys/cvc5
           if [ ! -f build/install/lib/libcvc5.a ]; then
@@ -102,7 +102,10 @@ jobs:
             make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
             make install
           fi
-          
+
+      - name: Build cvc5 (dynamic linking)
+        run: |
+          cd cvc5-sys/cvc5
           if [ ! -f build-dynamic/install/lib/libcvc5.so -a ! -f build-dynamic/install/lib/libcvc5.dylib ]; then
             ./configure.sh --name=build-dynamic --auto-download --prefix=$(pwd)/build-dynamic/install -DBUILD_GMP=1
             cd build-dynamic

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Build cvc5
         run: |
           cd cvc5-sys/cvc5
-          if [ ! -f build/src/libcvc5.a ]; then
+          if [ ! -f build/install/lib/libcvc5.a ]; then
             ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
             cd build
             make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
@@ -108,7 +108,7 @@ jobs:
             cd build-dynamic
             make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
             make install
-            cp libcadical.a libgmp* install/lib
+            cp deps/lib/libcadical.a deps/lib/libgmp* install/lib
           fi
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,25 +27,8 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake
-
-      - name: Cache cvc5 build
-        uses: actions/cache@v4
-        with:
-          path: cvc5-sys/cvc5/build
-          key: ${{ runner.os }}-cvc5-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-cvc5-
-
-      - name: Build cvc5
-        run: |
-          cd cvc5-sys/cvc5
-          if [ ! -f build/src/libcvc5.a ]; then
-            ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
-            cd build && make -j$(nproc)
-          fi
+      - name: Setup cvc5
+        uses: ./.github/actions/setup-cvc5
 
       - uses: Swatinem/rust-cache@v2
 
@@ -69,50 +52,10 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install build dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake
-
-      - name: Install build dependencies (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install cmake
-
-      - name: Cache cvc5 build (static linking)
-        uses: actions/cache@v4
+      - name: Setup cvc5
+        uses: ./.github/actions/setup-cvc5
         with:
-          path: cvc5-sys/cvc5/build
-          key: ${{ runner.os }}-cvc5-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-cvc5-
-
-      - name: Cache cvc5 build (dynamic linking)
-        uses: actions/cache@v4
-        with:
-          path: cvc5-sys/cvc5/build-dynamic
-          key: ${{ runner.os }}-cvc5-dynamic-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-cvc5-dynamic
-
-      - name: Build cvc5 (static linking)
-        run: |
-          cd cvc5-sys/cvc5
-          if [ ! -f build/install/lib/libcvc5.a ]; then
-            ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
-            cd build
-            make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
-            make install
-          fi
-
-      - name: Build cvc5 (dynamic linking)
-        run: |
-          cd cvc5-sys/cvc5
-          if [ ! -f build-dynamic/install/lib/libcvc5.so -a ! -f build-dynamic/install/lib/libcvc5.dylib ]; then
-            ./configure.sh --name=build-dynamic --auto-download --prefix=$(pwd)/build-dynamic/install -DBUILD_GMP=1
-            cd build-dynamic
-            make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
-            make install
-            cp deps/lib/libcadical.a deps/lib/libgmp* install/lib
-          fi
+          build-dynamic: 'true'
 
       - uses: Swatinem/rust-cache@v2
 
@@ -142,25 +85,8 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake
-
-      - name: Cache cvc5 build
-        uses: actions/cache@v4
-        with:
-          path: cvc5-sys/cvc5/build
-          key: ${{ runner.os }}-cvc5-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-cvc5-
-
-      - name: Build cvc5
-        run: |
-          cd cvc5-sys/cvc5
-          if [ ! -f build/src/libcvc5.a ]; then
-            ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
-            cd build && make -j$(nproc)
-          fi
+      - name: Setup cvc5
+        uses: ./.github/actions/setup-cvc5
 
       - uses: Swatinem/rust-cache@v2
 
@@ -183,25 +109,8 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential cmake
-
-      - name: Cache cvc5 build
-        uses: actions/cache@v4
-        with:
-          path: cvc5-sys/cvc5/build
-          key: ${{ runner.os }}-cvc5-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
-          restore-keys: ${{ runner.os }}-cvc5-
-
-      - name: Build cvc5
-        run: |
-          cd cvc5-sys/cvc5
-          if [ ! -f build/src/libcvc5.a ]; then
-            ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
-            cd build && make -j$(nproc)
-          fi
+      - name: Setup cvc5
+        uses: ./.github/actions/setup-cvc5
 
       - name: Build documentation
         run: cargo doc --all-features --no-deps

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,10 +118,10 @@ jobs:
       - name: Run tests (dynamic linking)
         run: cargo test --features parser
         env:
-          C_INCLUDE_PATH: -L${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/include
-          CPLUS_INCLUDE_PATH: -L${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/include
-          LDFLAGS: -L${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
-  
+          CVC5_LIB_DIR: ${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
+          DYLD_LIBRARY_PATH: ${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
+          LD_LIBRARY_PATH: ${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
+
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,9 +118,9 @@ jobs:
       - name: Run tests (dynamic linking)
         run: cargo test --features parser
         env:
-          CVC5_LIB_DIR: ${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
-          DYLD_LIBRARY_PATH: ${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
-          LD_LIBRARY_PATH: ${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
+          CVC5_LIB_DIR: ${{ github.workspace }}/cvc5-sys/cvc5/build-dynamic/install/lib
+          DYLD_LIBRARY_PATH: ${{ github.workspace }}/cvc5-sys/cvc5/build-dynamic/install/lib
+          LD_LIBRARY_PATH: ${{ github.workspace }}/cvc5-sys/cvc5/build-dynamic/install/lib
 
   lints:
     name: Lints

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,6 +108,7 @@ jobs:
             cd build-dynamic
             make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
             make install
+            cp libcadical.a libgmp* install/lib
           fi
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,26 +79,49 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install cmake
 
-      - name: Cache cvc5 build
+      - name: Cache cvc5 build (static linking)
         uses: actions/cache@v4
         with:
           path: cvc5-sys/cvc5/build
           key: ${{ runner.os }}-cvc5-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
           restore-keys: ${{ runner.os }}-cvc5-
 
+      - name: Cache cvc5 build (dynamic linking)
+        uses: actions/cache@v4
+        with:
+          path: cvc5-sys/cvc5/build-dynamic
+          key: ${{ runner.os }}-cvc5-dynamic-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
+          restore-keys: ${{ runner.os }}-cvc5-dynamic
+
       - name: Build cvc5
         run: |
           cd cvc5-sys/cvc5
           if [ ! -f build/src/libcvc5.a ]; then
             ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
-            cd build && make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+            cd build
+            make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+            make install
+          fi
+          
+          if [ ! -f build-dynamic/install/lib/libcvc5.so -a ! -f build-dynamic/install/lib/libcvc5.dylib ]; then
+            ./configure.sh --name=build-dynamic --auto-download --prefix=$(pwd)/build-dynamic/install -DBUILD_GMP=1
+            cd build-dynamic
+            make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+            make install
           fi
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run tests
-        run: cargo test --all-features
+      - name: Run tests (static linking)
+        run: cargo test --features static,parser
 
+      - name: Run tests (dynamic linking)
+        run: cargo test --features parser
+        env:
+          C_INCLUDE_PATH: -L${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/include
+          CPLUS_INCLUDE_PATH: -L${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/include
+          LDFLAGS: -L${{ env.GITHUB_ACTION_PATH }}/cvc5-sys/cvc5/build-dynamic/install/lib
+  
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ algebraic datatypes, and more.
 
 ## Version Correspondence
 
-| `cvc5` Version | `cvc5-sys` Version | `cvc5-rs` Version |
-|--------|---------|-----------|
-| 1.3.1  |  0.3.1  | >= 0.3.2 |
+| `cvc5` Version | `cvc5-sys` Version | `cvc5` Crate Version |
+|--------|--------------------|--------------------|
+| 1.3.1  | &gt;= 0.4 < 0.5    | &gt;= 0.4 < 0.5        |
 
 ## Prerequisites
 
-- cvc5 1.3.1 (included as a git submodule in `cvc5-sys/cvc5`; built automatically by `cvc5-sys` if needed)
+- cvc5 1.3.1 (included as a git submodule in `cvc5-sys/cvc5`; built automatically by `cvc5-sys` when the `static` feature is enabled)
 
-If building from source using the `static` feature, install
+If building from source using the `static` feature, install:
 
 - A C/C++ compiler, CMake ≥ 3.16, and libclang (for bindgen)
 - Git (for automatic source download when installed from crates.io)
@@ -37,7 +37,7 @@ git clone --recurse-submodules https://github.com/cvc5/cvc5-rs.git
 cd cvc5-rs
 
 # Build everything (cvc5 is compiled automatically on first run)
-cargo build
+cargo build --features static
 ```
 
 ## Usage
@@ -46,29 +46,53 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cvc5 = "0.3"
+cvc5 = "0.4"
+```
+
+Enable the `static` feature to statically link cvc5 and build it from source automatically:
+
+```toml
+[dependencies]
+cvc5 = { version = "0.4", features = ["static"] }
+```
+
+Without the `static` feature, cvc5 must be installed on the system or a path to shared library must be specified by
+`CVC5_LIB_DIR`. The build script discovers headers via `CVC5_INCLUDE_DIR`, `CVC5_LIB_DIR/../include`, or by asking the
+C compiler in this order.
+
+Enable the `parser` feature for SMT-LIB parsing support:
+
+```toml
+[dependencies]
+cvc5 = { version = "0.4", features = ["static", "parser"] }
 ```
 
 An application can set `CVC5_DIR` in its `.cargo/config.toml` to point to a local cvc5 checkout
-so that `cvc5-sys` can build against it:
+so that `cvc5-sys` can build against it (requires the `static` feature):
 
 ```toml
 [env]
 CVC5_DIR = { value = "cvc5", relative = true }
 ```
 
-Enable the `static` feature to statically-link against cvc5.
-
 ### Linking Against a Prebuilt cvc5
 
-If you already have cvc5 built, you can skip the automatic build by setting `CVC5_LIB_DIR` to the
-directory containing the static (if `static`) or dynamic libraries (`libcvc5.a`, etc.):
+If you already have cvc5 built and installed, you can skip the automatic build by setting
+`CVC5_LIB_DIR` to the directory containing the libraries:
 
 ```bash
-CVC5_LIB_DIR=/path/to/cvc5/build/lib cargo build
+CVC5_LIB_DIR=/path/to/cvc5/build/install/lib cargo build --features static
+```
+or
+```bash
+CVC5_LIB_DIR=/path/to/cvc5/build/install/lib cargo build
 ```
 
-Headers are expected at `$CVC5_LIB_DIR/../include` by default. To override, set `CVC5_INCLUDE_DIR`:
+Headers are resolved in this order:
+
+1. `CVC5_INCLUDE_DIR` environment variable (if set)
+2. `$CVC5_LIB_DIR/../include`
+3. Compiler discovery (the build script asks the C compiler to locate `cvc5/c/cvc5.h`)
 
 ```bash
 CVC5_LIB_DIR=/path/to/libs CVC5_INCLUDE_DIR=/path/to/include cargo build
@@ -80,7 +104,7 @@ CVC5_LIB_DIR=/path/to/libs CVC5_INCLUDE_DIR=/path/to/include cargo build
 use cvc5::{TermManager, Solver, Kind};
 
 let tm = TermManager::new();
-let mut solver = Solver::new( & tm);
+let mut solver = Solver::new(&tm);
 
 solver.set_logic("QF_LIA");
 solver.set_option("produce-models", "true");
@@ -89,7 +113,7 @@ let int_sort = tm.integer_sort();
 let x = tm.mk_const(int_sort, "x");
 let zero = tm.mk_integer(0);
 
-let gt = tm.mk_term(Kind::Gt, & [x.clone(), zero]);
+let gt = tm.mk_term(Kind::Gt, &[x.clone(), zero]);
 solver.assert_formula(gt);
 
 let result = solver.check_sat();
@@ -117,7 +141,15 @@ println!("x = {x_val}");
 - `Grammar` — for SyGuS (syntax-guided synthesis) problems.
 - `SynthResult` — result of a synthesis query.
 - `Proof` — proof objects when proof production is enabled.
-- `Statistics` — solver statistics.
+- `Statistics`, `Stat` — solver statistics.
+- `OptionInfo`, `OptionInfoKind` — solver option introspection.
+
+### Parser Types (parser feature)
+
+- `InputParser` — SMT-LIB input parser.
+- `SymbolManager` — symbol table for the parser.
+- `Command` — a parsed command.
+- `InputLanguage` — input language enum.
 
 ### Re-exported Enums
 
@@ -127,8 +159,14 @@ The following enums from `cvc5-sys` are re-exported for convenience:
 - `SortKind` — sort kinds (e.g., `BooleanSort`, `IntegerSort`, …)
 - `RoundingMode` — floating-point rounding modes
 - `ProofRule`, `ProofRewriteRule` — proof rules
+- `ProofComponent`, `ProofFormat` — proof output configuration
 - `SkolemId` — Skolem function identifiers
 - `UnknownExplanation` — reasons for unknown results
+- `BlockModelsMode` — model blocking modes
+- `LearnedLitType` — learned literal types
+- `FindSynthTarget` — synthesis targets
+- `OptionCategory` — option categories
+- `Plugin` — plugin interface
 
 ## Configuration
 

--- a/cvc5-sys/Cargo.toml
+++ b/cvc5-sys/Cargo.toml
@@ -20,6 +20,7 @@ static = []
 
 [build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
+cc = "1"
 toml = "0.8"
 convert_case = "^0.11"
 glob = "0.3"

--- a/cvc5-sys/Cargo.toml
+++ b/cvc5-sys/Cargo.toml
@@ -22,6 +22,7 @@ static = []
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
 toml = "0.8"
 convert_case = "^0.11"
+glob = "0.3"
 
 [package.metadata.docs.rs]
 features = ["parser", "static"]

--- a/cvc5-sys/Cargo.toml
+++ b/cvc5-sys/Cargo.toml
@@ -16,14 +16,14 @@ version = "1.3.1"
 
 [features]
 parser = []
-static = []
+static = ["dep:glob"]
 
 [build-dependencies]
 bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
 cc = "1"
 toml = "0.8"
 convert_case = "^0.11"
-glob = "0.3"
+glob = { version = "0.3", optional = true }
 
 [package.metadata.docs.rs]
 features = ["parser", "static"]

--- a/cvc5-sys/README.md
+++ b/cvc5-sys/README.md
@@ -9,33 +9,36 @@ For a safe, idiomatic Rust API, see the higher-level [`cvc5-rs`](https://github.
 
 When the `static` feature is enabled, this crate wraps cvc5 1.3.1 (the expected
 version is declared in `Cargo.toml` under `[package.metadata.cvc5]`). If cvc5
-has not been compiled yet, the build script runs `configure.sh --static
---auto-download` and `make` automatically. You need:
+has not been compiled yet, the build script builds cvc5 automatically. You need:
 
 - A C/C++ compiler (GCC or Clang)
 - CMake ≥ 3.16
 - libclang (required by bindgen)
 - Git (for automatic source download when installed from crates.io)
 
-## Source Acquisition
+Without the `static` feature, the build script does not build cvc5 from source.
+Instead it expects cvc5 to be installed on the system or in a path pointed to by `CVC5_LIB_DIR`,
+and discovers headers via `CVC5_INCLUDE_DIR` or by asking the C compiler.
+
+## Source acquisition (static feature)
 
 The build script locates the cvc5 source in the following order:
 
-1. **`CVC5_DIR` environment variable** — set to the cvc5 source root containing `include/` and `build/` directories.
+1. **`CVC5_DIR` environment variable** — set to the cvc5 source root.
 2. **`cvc5/` subdirectory** inside the `cvc5-sys` crate — the default when using the git submodule.
-3. **Sibling `cvc5/` directory** — a built cvc5 checkout next to the `cvc5-sys` crate (workspace layout).
-4. **Automatic clone** — if none of the above are found, the build script clones the matching cvc5 release tag from GitHub.
+3. **Automatic clone** — if none of the above are found, the build script clones the matching cvc5 release tag from
+   GitHub into `OUT_DIR`.
 
 ```bash
 # Option 1: explicit path
-CVC5_DIR=/path/to/cvc5 cargo build
+CVC5_DIR=/path/to/cvc5 cargo build --features static
 
 # Option 2: submodule (no env var needed)
 git clone --recurse-submodules https://github.com/cvc5/cvc5-rs.git
-cd cvc5-rs && cargo build
+cd cvc5-rs && cargo build --features static
 
 # Option 3: from crates.io (auto-clones cvc5)
-cargo add cvc5-sys
+cargo add cvc5-sys --features static
 cargo build
 ```
 
@@ -46,31 +49,44 @@ An application can set `CVC5_DIR` in its `.cargo/config.toml` to point to a loca
 CVC5_DIR = { value = "cvc5", relative = true }
 ```
 
-## Linking Against a Prebuilt cvc5
+## Linking against a prebuilt cvc5
 
-If you already have cvc5 built, you can skip the automatic build by setting `CVC5_LIB_DIR` to the
-directory containing the static (if `static`) or dynamic libraries (`libcvc5.a`, etc.):
+If you already have cvc5 built and installed, you can skip the automatic build by setting
+`CVC5_LIB_DIR` to the directory containing the libraries (`libcvc5.a` for static, or
+`libcvc5.so`/`libcvc5.dylib` for dynamic):
 
 ```bash
-CVC5_LIB_DIR=/path/to/cvc5/build/lib cargo build
+CVC5_LIB_DIR=/path/to/cvc5/build/install/lib cargo build --features static # for static linking
 ```
 
-Headers are expected at `$CVC5_LIB_DIR/../include` by default. To override, set `CVC5_INCLUDE_DIR`:
+or
 
 ```bash
+CVC5_LIB_DIR=/path/to/cvc5/build/install/lib cargo build # for dynamic linking
+```
+
+Headers are resolved in this order:
+
+1. `CVC5_INCLUDE_DIR` environment variable (if set)
+2. `$CVC5_LIB_DIR/../include` (the conventional install layout)
+3. Compiler discovery — the build script asks the C compiler to locate `cvc5/c/cvc5.h` on the system include path
+
+```bash
+# Override both paths explicitly
 CVC5_LIB_DIR=/path/to/libs CVC5_INCLUDE_DIR=/path/to/include cargo build
 ```
 
 ## Features
 
-| Feature  | Description                                       |
-|----------|---------------------------------------------------|
-| `parser` | Also generate and link bindings for `cvc5parser`. |
+| Feature  | Description                                                                                                                                                                                 |
+|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `static` | Statically link cvc5. Enables automatic source build if cvc5 is not already compiled.<br/> Otherwise, the crate employs dynamic linking to cvc5 and assume some local installation of cvc5. |
+| `parser` | Also generate and link bindings for `cvc5parser`.                                                                                                                                           |
 
 Enable with:
 
 ```bash
-cargo build --features parser
+cargo build --features static,parser
 ```
 
 ## Usage
@@ -102,13 +118,16 @@ unsafe {
 }
 ```
 
-## Linked Libraries
+## Linked libraries
 
-The build script statically links:
+When the `static` feature is enabled, the build script statically links:
 
 - `libcvc5` (and `libcvc5parser` with the `parser` feature)
-- Bundled dependencies when present: `cadical`, `picpoly`, `picpolyxx`, `gmp`
+- Bundled dependencies: `cadical`, `picpoly`, `picpolyxx`, `gmp`
 - The platform C++ standard library (`libc++` on macOS, `libstdc++` on Linux)
+- `libstdc++_nonshared` on RHEL/CentOS with GCC toolsets (detected automatically)
+
+The build script supports both `lib/` and `lib64/` install layouts.
 
 ## License
 

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -266,6 +266,9 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
     if cvc5_dir.join("build/install/lib/libcvc5.a").exists() {
         return (include_dir, Some(cvc5_dir.join("build/install/lib")));
     }
+    if cvc5_dir.join("build/install/lib64/libcvc5.a").exists() {
+        return (include_dir, Some(cvc5_dir.join("build/install/lib64")));
+    }
 
     eprintln!("cvc5 not yet built — running configure and make (this may take a while)...");
 
@@ -306,10 +309,23 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
         .status()
         .expect("Failed to run make");
     assert!(status.success(), "cvc5 install failed");
-    return (
+    let lib_dir = {
+        let p = cvc5_dir.join("build/install/lib");
+        if p.exists() {
+            p
+        } else {
+            let p = cvc5_dir.join("build/install/lib64");
+            if p.exists() {
+                p
+            } else {
+                panic!("Not able to find a lib folder in {}!", build_dir.display());
+            }
+        }
+    };
+    (
         Some(include_dir.unwrap_or_else(|| cvc5_dir.join("build/install/include"))),
-        Some(cvc5_dir.join("build/install/lib")),
-    );
+        Some(lib_dir),
+    )
 }
 
 #[cfg(not(unix))]

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -293,14 +293,8 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
         .map(|n| n.get().to_string())
         .unwrap_or_else(|_| "4".to_string());
 
-    let mut targets: Vec<&str> = vec!["cvc5"];
-    if cfg!(feature = "parser") {
-        targets.push("cvc5parser");
-    }
-
     let status = Command::new("make")
         .arg(format!("-j{jobs}"))
-        .args(targets)
         .current_dir(cvc5_dir.join("build"))
         .status()
         .expect("Failed to run make");

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -1,12 +1,12 @@
-use std::path::Path;
-use std::{env, path::PathBuf, process::Command};
+use std::{env, path::PathBuf};
 
 use bindgen::callbacks::{ItemKind, ParseCallbacks};
 use convert_case::{Case, Casing as _};
+
 #[cfg(feature = "static")]
-const LIB_EXTENSION: &str = "a";
-#[cfg(not(feature = "static"))]
-const LIB_EXTENSION: &str = "so";
+use std::path::Path;
+#[cfg(feature = "static")]
+use std::process::Command;
 
 fn link_with(name: &str) {
     #[cfg(feature = "static")]
@@ -39,62 +39,35 @@ fn main() {
         return;
     }
 
-    // If CVC5_LIB_DIR is set, link directly without building cvc5.
-    if let Ok(lib_dir) = env::var("CVC5_LIB_DIR") {
-        link_prebuilt(&PathBuf::from(lib_dir));
-        return;
-    }
+    // If CVC5_LIB_DIR is set, resolve the path according to the given path
+    let (include_dir, lib_dir) = if let Ok(lib_dir) = env::var("CVC5_LIB_DIR") {
+        resolve_paths_given_lib_dir(PathBuf::from(lib_dir))
+    } else {
+        ensure_cvc5_built_and_install()
+    };
+    lib_dir.iter().for_each(|lib_dir| {
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    });
 
-    let cvc5_dir = find_cvc5_dir();
-    let expected = read_expected_cvc5_version();
-    check_cvc5_version(&cvc5_dir, &expected);
-    #[cfg(feature = "static")]
-    ensure_cvc5_built(&cvc5_dir);
-
-    let include_dir = cvc5_dir.join("include");
-    let build_dir = cvc5_dir.join("build");
-    let build_include_dir = build_dir.join("include");
-
-    // Link against the static library
-    println!(
-        "cargo:rustc-link-search=native={}",
-        build_dir.join("src").display()
-    );
     link_with("cvc5");
-
     // Link parser library
     if cfg!(feature = "parser") {
-        println!(
-            "cargo:rustc-link-search=native={}",
-            build_dir.join("src/parser").display()
-        );
         link_with("cvc5parser");
     }
 
-    // Link dependencies
-    let deps_lib = build_dir.join("deps/lib");
-    if deps_lib.exists() {
-        println!("cargo:rustc-link-search=native={}", deps_lib.display());
-        for lib in &["cadical", "gmp"] {
-            let path = deps_lib.join(format!("lib{lib}.{LIB_EXTENSION}"));
-            if path.exists() {
-                link_with(lib);
-            }
-        }
-        #[cfg(feature = "static")]
-        for lib in &["picpoly", "picpolyxx"] {
-            let path = deps_lib.join(format!("lib{lib}.{LIB_EXTENSION}"));
-            if path.exists() {
-                link_with(lib);
-            }
-        }
+    for lib in &["cadical", "gmp"] {
+        link_with(lib);
+    }
+    #[cfg(feature = "static")]
+    for lib in &["picpoly", "picpolyxx"] {
+        link_with(lib);
     }
 
     // Link C++ stdlib
     link_cxx_stdlib();
 
     // Generate bindings
-    generate_bindings(&include_dir, &build_include_dir);
+    generate_bindings(include_dir);
 }
 
 /// Renames enums
@@ -155,19 +128,19 @@ impl ParseCallbacks for RenamingCallback {
     }
 }
 
-fn generate_bindings(include_dir: &Path, build_include_dir: &Path) {
+fn generate_bindings(include_dir: Option<PathBuf>) {
     // Generate bindings from the C API header
-    let header = include_dir.join("cvc5/c/cvc5.h");
-    assert!(
-        header.exists(),
-        "cvc5 C header not found at {}",
-        header.display()
-    );
+    let header = "cvc5/c/cvc5.h";
 
-    let bindings = bindgen::Builder::default()
-        .header(header.to_string_lossy())
-        .clang_arg(format!("-I{}", include_dir.display()))
-        .clang_arg(format!("-I{}", build_include_dir.display()))
+    let builder = bindgen::Builder::default();
+    let builder = match include_dir.as_ref() {
+        Some(include_dir) => builder
+            .header(include_dir.join(header).to_string_lossy())
+            .clang_arg(format!("-I{}", include_dir.display())),
+        None => builder.header(header),
+    };
+
+    let bindings = builder
         .parse_callbacks(Box::new(RenamingCallback))
         .clang_arg("-DCVC5_STATIC_DEFINE")
         .allowlist_function("cvc5_.*")
@@ -201,43 +174,47 @@ fn generate_bindings(include_dir: &Path, build_include_dir: &Path) {
 
     // Generate parser bindings if feature enabled
     if cfg!(feature = "parser") {
-        let parser_header = include_dir.join("cvc5/c/cvc5_parser.h");
-        if parser_header.exists() {
-            let parser_bindings = bindgen::Builder::default()
-                .header(parser_header.to_string_lossy())
-                .clang_arg(format!("-I{}", include_dir.display()))
-                .clang_arg(format!("-I{}", build_include_dir.display()))
-                .clang_arg("-DCVC5_STATIC_DEFINE")
-                .parse_callbacks(Box::new(RenamingCallback))
-                .allowlist_function("cvc5_parser_.*")
-                .allowlist_function("cvc5_cmd_.*")
-                .allowlist_function("cvc5_symbol_manager_.*")
-                .allowlist_function("cvc5_sm_.*")
-                .allowlist_type("Cvc5InputParser")
-                .allowlist_type("Cvc5SymbolManager")
-                .allowlist_type("Cvc5Command")
-                .allowlist_type("cvc5_cmd_t")
-                .blocklist_type("Cvc5")
-                .blocklist_type("Cvc5TermManager")
-                .blocklist_type("Cvc5Sort")
-                .blocklist_type("cvc5_sort_t")
-                .blocklist_type("Cvc5Term")
-                .blocklist_type("cvc5_term_t")
-                .blocklist_type("Cvc5InputLanguage")
-                .raw_line("use super::*;")
-                .generate_comments(true)
-                .derive_default(true)
-                .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-                .generate()
-                .expect("Unable to generate cvc5 parser bindings");
+        let parser_header = "cvc5/c/cvc5_parser.h";
+        let builder = bindgen::Builder::default();
+        let builder = match include_dir.as_ref() {
+            Some(include_dir) => builder
+                .header(include_dir.join(parser_header).to_string_lossy())
+                .clang_arg(format!("-I{}", include_dir.display())),
+            None => builder.header(parser_header),
+        };
 
-            parser_bindings
-                .write_to_file(out_path.join("parser_bindings.rs"))
-                .expect("Couldn't write parser bindings!");
-        }
+        let parser_bindings = builder
+            .clang_arg("-DCVC5_STATIC_DEFINE")
+            .parse_callbacks(Box::new(RenamingCallback))
+            .allowlist_function("cvc5_parser_.*")
+            .allowlist_function("cvc5_cmd_.*")
+            .allowlist_function("cvc5_symbol_manager_.*")
+            .allowlist_function("cvc5_sm_.*")
+            .allowlist_type("Cvc5InputParser")
+            .allowlist_type("Cvc5SymbolManager")
+            .allowlist_type("Cvc5Command")
+            .allowlist_type("cvc5_cmd_t")
+            .blocklist_type("Cvc5")
+            .blocklist_type("Cvc5TermManager")
+            .blocklist_type("Cvc5Sort")
+            .blocklist_type("cvc5_sort_t")
+            .blocklist_type("Cvc5Term")
+            .blocklist_type("cvc5_term_t")
+            .blocklist_type("Cvc5InputLanguage")
+            .raw_line("use super::*;")
+            .generate_comments(true)
+            .derive_default(true)
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+            .generate()
+            .expect("Unable to generate cvc5 parser bindings");
+
+        parser_bindings
+            .write_to_file(out_path.join("parser_bindings.rs"))
+            .expect("Couldn't write parser bindings!");
     }
 }
 
+#[cfg(feature = "static")]
 fn read_expected_cvc5_version() -> String {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml");
     let content = std::fs::read_to_string(&manifest).expect("Failed to read Cargo.toml");
@@ -248,6 +225,7 @@ fn read_expected_cvc5_version() -> String {
         .to_string()
 }
 
+#[cfg(feature = "static")]
 fn check_cvc5_version(cvc5_dir: &Path, expected: &str) {
     let version_file = cvc5_dir.join("cmake/version-base.cmake");
     assert!(
@@ -276,11 +254,17 @@ fn check_cvc5_version(cvc5_dir: &Path, expected: &str) {
     println!("cargo:rerun-if-changed={}", version_file.display());
 }
 
+// return (include path, lib path) if exist
+
 #[cfg(unix)]
 #[cfg(feature = "static")]
-fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
-    if cvc5_dir.join("build/src/libcvc5.a").exists() {
-        return;
+fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
+    let cvc5_dir = find_cvc5_dir();
+    let expected = read_expected_cvc5_version();
+    check_cvc5_version(&cvc5_dir, &expected);
+    let include_dir = find_cvc5_include_dir();
+    if cvc5_dir.join("build/install/lib/libcvc5.a").exists() {
+        return (include_dir, Some(cvc5_dir.join("build/install/lib")));
     }
 
     eprintln!("cvc5 not yet built — running configure and make (this may take a while)...");
@@ -300,7 +284,7 @@ fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
         .arg("--auto-download")
         .arg(format!("--prefix={}/install", build_dir.display()))
         .arg("-DBUILD_GMP=1")
-        .current_dir(cvc5_dir)
+        .current_dir(&cvc5_dir)
         .status()
         .expect("Failed to run configure.sh");
     assert!(status.success(), "cvc5 configure.sh failed");
@@ -321,18 +305,39 @@ fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
         .status()
         .expect("Failed to run make");
     assert!(status.success(), "cvc5 build failed");
+
+    let status = Command::new("make")
+        .arg("install")
+        .current_dir(cvc5_dir.join("build"))
+        .status()
+        .expect("Failed to run make");
+    assert!(status.success(), "cvc5 install failed");
+    return (
+        Some(include_dir.unwrap_or_else(|| cvc5_dir.join("build/install/include"))),
+        Some(cvc5_dir.join("build/install/lib")),
+    );
 }
 
 #[cfg(not(unix))]
 #[cfg(feature = "static")]
-fn ensure_cvc5_built(cvc5_dir: &PathBuf) {
-    assert!(
-        cvc5_dir.join("build/src/libcvc5.a").exists(),
-        "cvc5 is not built and automatic building is only supported on Unix. \
-         Please build cvc5 manually before running cargo build."
-    );
+fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
+    panic!("This rust binding for cvc5 is only supported on Unix systems!.");
 }
 
+#[cfg(not(feature = "static"))]
+fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
+    (find_cvc5_include_dir(), None)
+}
+
+fn find_cvc5_include_dir() -> Option<PathBuf> {
+    println!("cargo:rerun-if-env-changed=CVC5_INCLUDE_DIR");
+    match env::var("CVC5_INCLUDE_DIR") {
+        Ok(d) => Some(PathBuf::from(d)),
+        Err(_) => None,
+    }
+}
+
+#[cfg(feature = "static")]
 fn find_cvc5_dir() -> PathBuf {
     // 1. Check CVC5_DIR env var
     println!("cargo:rerun-if-env-changed=CVC5_DIR");
@@ -371,13 +376,7 @@ fn find_cvc5_dir() -> PathBuf {
     out
 }
 
-/// Link against prebuilt cvc5 libraries and generate bindings.
-///
-/// `lib_dir` is the directory containing the static libraries (libcvc5.a, etc.).
-/// Headers are located via `CVC5_INCLUDE_DIR` env var, or `<lib_dir>/../include`.
-fn link_prebuilt(lib_dir: &Path) {
-    println!("cargo:rerun-if-env-changed=CVC5_INCLUDE_DIR");
-
+fn resolve_paths_given_lib_dir(lib_dir: PathBuf) -> (Option<PathBuf>, Option<PathBuf>) {
     assert!(
         lib_dir.exists(),
         "CVC5_LIB_DIR does not exist: {}",
@@ -385,10 +384,7 @@ fn link_prebuilt(lib_dir: &Path) {
     );
 
     // Find include directory
-    let include_dir = match env::var("CVC5_INCLUDE_DIR") {
-        Ok(d) => PathBuf::from(d),
-        Err(_) => lib_dir.join("../include"),
-    };
+    let include_dir = find_cvc5_include_dir().unwrap_or_else(|| lib_dir.join("../include"));
     let include_dir = include_dir.canonicalize().unwrap_or_else(|_| {
         panic!(
             "Include directory not found. Set CVC5_INCLUDE_DIR or ensure \
@@ -397,30 +393,7 @@ fn link_prebuilt(lib_dir: &Path) {
         )
     });
 
-    // Link
-    println!("cargo:rustc-link-search=native={}", lib_dir.display());
-    link_with("cvc5");
-
-    if cfg!(feature = "parser") {
-        link_with("cvc5parser");
-    }
-
-    // Link bundled dependencies if present
-    for lib in &["cadical", "gmp"] {
-        if lib_dir.join(format!("lib{lib}.{LIB_EXTENSION}")).exists() {
-            link_with(lib);
-        }
-    }
-    #[cfg(feature = "static")]
-    for lib in &["picpoly", "picpolyxx"] {
-        let path = lib_dir.join(format!("lib{lib}.{LIB_EXTENSION}"));
-        if path.exists() {
-            link_with(lib);
-        }
-    }
-
-    link_cxx_stdlib();
-    generate_bindings(&include_dir, &include_dir);
+    (Some(include_dir), Some(lib_dir))
 }
 
 fn link_cxx_stdlib() {

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -7,7 +7,6 @@ use convert_case::{Case, Casing as _};
 use std::fs;
 #[cfg(feature = "static")]
 use std::path::Path;
-#[cfg(feature = "static")]
 use std::process::Command;
 
 fn link_with(name: &str) {
@@ -344,10 +343,9 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
 
 /// Ask the C compiler to resolve `cvc5/c/cvc5.h` and return its include
 /// directory (the parent of `cvc5/`).
-#[cfg(not(feature = "static"))]
 fn discover_include_dir() -> Option<PathBuf> {
     let compiler = cc::Build::new().cargo_warnings(false).get_compiler();
-    let output = std::process::Command::new(compiler.path())
+    let output = Command::new(compiler.path())
         .args(compiler.args())
         .args(["-E", "-M", "-xc", "-"])
         .stdin(std::process::Stdio::piped())
@@ -433,13 +431,17 @@ fn resolve_paths_given_lib_dir(lib_dir: PathBuf) -> (Option<PathBuf>, Option<Pat
 
     // Find include directory
     let include_dir = find_cvc5_include_dir().unwrap_or_else(|| lib_dir.join("../include"));
-    let include_dir = include_dir.canonicalize().unwrap_or_else(|_| {
-        panic!(
-            "Include directory not found. Set CVC5_INCLUDE_DIR or ensure \
+    let include_dir = include_dir
+        .canonicalize()
+        .ok()
+        .or_else(discover_include_dir)
+        .unwrap_or_else(|| {
+            panic!(
+                "Include directory not found. Set CVC5_INCLUDE_DIR or ensure \
              {}/include exists.",
-            lib_dir.join("..").display()
-        )
-    });
+                lib_dir.join("..").display()
+            )
+        });
 
     (Some(include_dir), Some(lib_dir))
 }

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -262,12 +262,16 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
     let cvc5_dir = find_cvc5_dir();
     let expected = read_expected_cvc5_version();
     check_cvc5_version(&cvc5_dir, &expected);
-    let include_dir = find_cvc5_include_dir();
+    let include_dir =
+        find_cvc5_include_dir().unwrap_or_else(|| cvc5_dir.join("build/install/include"));
     if cvc5_dir.join("build/install/lib/libcvc5.a").exists() {
-        return (include_dir, Some(cvc5_dir.join("build/install/lib")));
+        return (Some(include_dir), Some(cvc5_dir.join("build/install/lib")));
     }
     if cvc5_dir.join("build/install/lib64/libcvc5.a").exists() {
-        return (include_dir, Some(cvc5_dir.join("build/install/lib64")));
+        return (
+            Some(include_dir),
+            Some(cvc5_dir.join("build/install/lib64")),
+        );
     }
 
     eprintln!("cvc5 not yet built — running configure and make (this may take a while)...");
@@ -322,10 +326,7 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
             }
         }
     };
-    (
-        Some(include_dir.unwrap_or_else(|| cvc5_dir.join("build/install/include"))),
-        Some(lib_dir),
-    )
+    (Some(include_dir), Some(lib_dir))
 }
 
 #[cfg(not(unix))]

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -1,4 +1,4 @@
-use std::{env, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 use bindgen::callbacks::{ItemKind, ParseCallbacks};
 use convert_case::{Case, Casing as _};
@@ -326,6 +326,14 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
             }
         }
     };
+
+    // GMP work around; c.f. https://github.com/cvc5/cvc5/pull/12168
+    for file in glob::glob(&build_dir.join("deps/lib/libgmp.*").to_string_lossy()).unwrap() {
+        let file = file.unwrap();
+        let dest = lib_dir.join(file.file_name().unwrap());
+        fs::copy(file, dest).unwrap();
+    }
+
     (Some(include_dir), Some(lib_dir))
 }
 

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -57,11 +57,8 @@ fn main() {
         link_with("cvc5parser");
     }
 
-    for lib in &["cadical", "gmp"] {
-        link_with(lib);
-    }
     #[cfg(feature = "static")]
-    for lib in &["picpoly", "picpolyxx"] {
+    for lib in &["cadical", "picpoly", "picpolyxx", "gmp"] {
         link_with(lib);
     }
 

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -465,4 +465,27 @@ fn link_cxx_stdlib() {
     if let Some(cxx) = cxx {
         println!("cargo:rustc-link-lib={cxx}");
     }
+
+    // On RHEL/CentOS with GCC toolsets (e.g. gcc-toolset-10), newer C++ symbols
+    // live in libstdc++_nonshared.a rather than the base system libstdc++.so.
+    // If cvc5 was compiled with such a GCC, we must link this supplemental library.
+    #[cfg(feature = "static")]
+    if let Ok(output) = Command::new(cc::Build::new().cpp(true).get_compiler().path())
+        .arg("-print-search-dirs")
+        .output()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            if let Some(dirs) = line.strip_prefix("libraries: =") {
+                for dir in dirs.split(':') {
+                    let dir = Path::new(dir);
+                    if dir.join("libstdc++_nonshared.a").exists() {
+                        println!("cargo:rustc-link-search=native={}", dir.display());
+                        println!("cargo:rustc-link-lib=static=stdc++_nonshared");
+                        return;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/cvc5-sys/build.rs
+++ b/cvc5-sys/build.rs
@@ -1,8 +1,10 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, path::PathBuf};
 
 use bindgen::callbacks::{ItemKind, ParseCallbacks};
 use convert_case::{Case, Casing as _};
 
+#[cfg(feature = "static")]
+use std::fs;
 #[cfg(feature = "static")]
 use std::path::Path;
 #[cfg(feature = "static")]
@@ -343,9 +345,39 @@ fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
     panic!("This rust binding for cvc5 is only supported on Unix systems!.");
 }
 
+/// Ask the C compiler to resolve `cvc5/c/cvc5.h` and return its include
+/// directory (the parent of `cvc5/`).
+#[cfg(not(feature = "static"))]
+fn discover_include_dir() -> Option<PathBuf> {
+    let compiler = cc::Build::new().cargo_warnings(false).get_compiler();
+    let output = std::process::Command::new(compiler.path())
+        .args(compiler.args())
+        .args(["-E", "-M", "-xc", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(b"#include <cvc5/c/cvc5.h>\n")?;
+            child.wait_with_output()
+        })
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let suffix = "/cvc5/c/cvc5.h";
+    stdout.split_whitespace().find_map(|token| {
+        let path = token.strip_suffix(suffix)?;
+        Some(PathBuf::from(path))
+    })
+}
+
 #[cfg(not(feature = "static"))]
 fn ensure_cvc5_built_and_install() -> (Option<PathBuf>, Option<PathBuf>) {
-    (find_cvc5_include_dir(), None)
+    (find_cvc5_include_dir().or_else(discover_include_dir), None)
 }
 
 fn find_cvc5_include_dir() -> Option<PathBuf> {


### PR DESCRIPTION
Closes #51 

~~This is the initial stab; I will test locally.~~

the changes are working for both static and dynamic linking (with special env vars to by pass the need to install system-wide) for me. The build script is also cleaned up to maximize shared code path.