### PR TITLE
fix the cvc5 setup action

### DIFF
--- a/.github/actions/setup-cvc5/action.yml
+++ b/.github/actions/setup-cvc5/action.yml
@@ -24,38 +24,35 @@ runs:
 
     - name: Cache cvc5 build (static)
       uses: actions/cache@v4
+      id: cache-static
       with:
         path: cvc5-sys/cvc5/build
         key: ${{ runner.os }}-cvc5-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
-        restore-keys: ${{ runner.os }}-cvc5-
 
     - name: Build cvc5 (static)
+      if: steps.cache-static.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd cvc5-sys/cvc5
-        if [ ! -f build/install/lib/libcvc5.a ]; then
-          ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
-          cd build
-          make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
-          make install
-        fi
+        ./configure.sh --static --auto-download --prefix=$(pwd)/build/install -DBUILD_GMP=1
+        cd build
+        make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+        make install
 
     - name: Cache cvc5 build (dynamic)
       if: inputs.build-dynamic == 'true'
       uses: actions/cache@v4
+      id: cache-dynamic
       with:
         path: cvc5-sys/cvc5/build-dynamic
         key: ${{ runner.os }}-cvc5-dynamic-${{ hashFiles('cvc5-sys/cvc5/**/*.cmake', 'cvc5-sys/cvc5/CMakeLists.txt') }}
-        restore-keys: ${{ runner.os }}-cvc5-dynamic
 
     - name: Build cvc5 (dynamic)
-      if: inputs.build-dynamic == 'true'
+      if: inputs.build-dynamic == 'true' && steps.cache-dynamic.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd cvc5-sys/cvc5
-        if [ ! -f build-dynamic/install/lib/libcvc5.so -a ! -f build-dynamic/install/lib/libcvc5.dylib ]; then
-          ./configure.sh --name=build-dynamic --auto-download --prefix=$(pwd)/build-dynamic/install -DBUILD_GMP=1
-          cd build-dynamic
-          make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
-          make install
-        fi
+        ./configure.sh --name=build-dynamic --auto-download --prefix=$(pwd)/build-dynamic/install -DBUILD_GMP=1
+        cd build-dynamic
+        make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+        make install


### PR DESCRIPTION
The current cvc5 setup action could be confused about existing caches. This fix is making the action more robust. 